### PR TITLE
Better explain the `preLandoFiles` and `postLandoFiles` config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ On the flip side, you might have some user-specific configuration you'd like to 
 
 ## Configuration
 
-The base override and Landofile itself are all configurable via the Lando [global config](./global.md). The default values are shown below:
+The `.lando.base.yml`, `.lando.local.yml` and `.lando.yml` itself are all configurable via the Lando [global config](./global.md). The default values are shown below:
 
 ```yaml
 landoFile: .lando.yml


### PR DESCRIPTION
I am not sure exactly how to word this, maybe something like...

Three configurations that determine the order of precedence of lando configuration files are:
1. `preLandoFiles` Can be overridden by the next two.
2. `Landofile` Can be overridden by the next one
3. `postLandoFiles` Can not be overridden except by another `postLandoFile`

