### PR TITLE
Document that a rebuild / destroy is needed when updating .lando.local.yml

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ On the flip side, you might have some user-specific configuration you'd like to 
 .lando.local.yml
 ```
 
+Any changes to your `.lando.local.yml` file take effect after doing a `lando rebuild`. If the basic `config` is overridden, a `lando destroy` is also needed to fully reset the configuration.
+
 ## Configuration
 
 The base override and Landofile itself are all configurable via the Lando [global config](./global.md). The default values are shown below:


### PR DESCRIPTION
Any changes to `.lando.local.yml` only take effect when doing a `lando rebuild`, but in the case of making changes to the `config` section, a full destroy + rebuild is needed. Let's document this since it can be puzzling to users why their changes are not being applied.