### PR TITLE
Add tips on how to disable HTTPS-Only Mode in Firefox, to allow a http URL

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -163,6 +163,19 @@ The former will tell the service to attempt to generate a certificate.
 
 The latter will expose the secure port (usually 443) for the service and assign a `localhost:someport` address to the service. This means that if your service does not actually plan to serve https by itself you may experience a hang as Lando tries to health scan a `localhost` https address that doesn't actually serve https. In these scenarios its best to tell Lando you just want a cert.
 
+**just generate a cert**
+
+```yaml
+services:
+  web:
+    ssl: true
+    sslExpose: false
+```
+
+In some rare scenarios a service does not boot up as `root`. This is especially true for the `compose` service. In these situations Lando will be unable to generate a cert and will fall back to the global wildcard certificate for the `proxyDomain` which is `*.lndo.site` by default.
+
+This means that subdomains like `sub.mysite.lndo.site` will likely produce a browser warning. However, domains like `sub-mysite.lndo.site` will continue to work since they are covered by the global wildcard cert.
+
 ### Disable HTTPS-Only Mode in Firefox, to allow a http URL
 
 By default, Firefox will redirect `http` domains to `https`, which can result in a `404 page not found` error for proxy URLs.
@@ -188,19 +201,6 @@ PMA URLS  http://localhost:49199
 ```
 
 If you visit the URL `http://pma.lndo.site/` in Firefox, it will be redirected to `https://pma.lndo.site/` resulting in a `404 page not found` error. To fix this, disable HTTPS-Only Mode following the steps under [Add exceptions for HTTP websites when you’re in HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode).
-
-**just generate a cert**
-
-```yaml
-services:
-  web:
-    ssl: true
-    sslExpose: false
-```
-
-In some rare scenarios a service does not boot up as `root`. This is especially true for the `compose` service. In these situations Lando will be unable to generate a cert and will fall back to the global wildcard certificate for the `proxyDomain` which is `*.lndo.site` by default.
-
-This means that subdomains like `sub.mysite.lndo.site` will likely produce a browser warning. However, domains like `sub-mysite.lndo.site` will continue to work since they are covered by the global wildcard cert.
 
 ### Advanced
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -163,6 +163,32 @@ The former will tell the service to attempt to generate a certificate.
 
 The latter will expose the secure port (usually 443) for the service and assign a `localhost:someport` address to the service. This means that if your service does not actually plan to serve https by itself you may experience a hang as Lando tries to health scan a `localhost` https address that doesn't actually serve https. In these scenarios its best to tell Lando you just want a cert.
 
+### Disable HTTPS-Only Mode in Firefox, to allow a http URL
+
+By default, Firefox will redirect `http` domains to `https`, which can result in a `404 page not found` error for proxy URLs.
+
+For example, you can add phpMyAdmin as a service with this:
+
+```
+services:
+  pma:
+    type: phpmyadmin
+    hosts:
+      - database
+proxy:
+  pma:
+    - pma.lndo.site
+```
+
+... which will be available at these URLs, where port number `49199` is dynamic:
+
+```
+PMA URLS  http://localhost:49199        
+          http://pma.lndo.site/        
+```
+
+If you visit the URL `http://pma.lndo.site/` in Firefox, it will be redirected to `https://pma.lndo.site/` resulting in a `404 page not found` error. To fix this, disable HTTPS-Only Mode following the steps under [Add exceptions for HTTP websites when you’re in HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode).
+
 **just generate a cert**
 
 ```yaml

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -176,31 +176,11 @@ In some rare scenarios a service does not boot up as `root`. This is especially 
 
 This means that subdomains like `sub.mysite.lndo.site` will likely produce a browser warning. However, domains like `sub-mysite.lndo.site` will continue to work since they are covered by the global wildcard cert.
 
-### Disable HTTPS-Only Mode in Firefox, to allow a http URL
+#### Proxy URLs Create 404 Error in Firefox
 
-By default, Firefox will redirect `http` domains to `https`, which can result in a `404 page not found` error for proxy URLs.
+By default, Firefox will redirect `http` domains to `https`. If you have not [enabled https for your proxy URLs](#using-https), this will mean your proxy URLs will result in a `404 page not found` error
 
-For example, you can add phpMyAdmin as a service with this:
-
-```yaml
-services:
-  pma:
-    type: phpmyadmin
-    hosts:
-      - database
-proxy:
-  pma:
-    - pma.lndo.site
-```
-
-... which will be available at these URLs, where port number `49199` is dynamic:
-
-```bash
-PMA URLS  http://localhost:49199        
-          http://pma.lndo.site/        
-```
-
-If you visit the URL `http://pma.lndo.site/` in Firefox, it will be redirected to `https://pma.lndo.site/` resulting in a `404 page not found` error. To fix this, disable HTTPS-Only Mode following the steps under [Add exceptions for HTTP websites when you’re in HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode).
+To fix this, either enable https for your Lando proxy urls, or disable HTTPS-Only Mode in Firefox following the steps under [Add exceptions for HTTP websites when you’re in HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode).
 
 ### Advanced
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -169,7 +169,7 @@ By default, Firefox will redirect `http` domains to `https`, which can result in
 
 For example, you can add phpMyAdmin as a service with this:
 
-```
+```yaml
 services:
   pma:
     type: phpmyadmin
@@ -182,7 +182,7 @@ proxy:
 
 ... which will be available at these URLs, where port number `49199` is dynamic:
 
-```
+```bash
 PMA URLS  http://localhost:49199        
           http://pma.lndo.site/        
 ```

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -178,7 +178,7 @@ This means that subdomains like `sub.mysite.lndo.site` will likely produce a bro
 
 #### Proxy URLs Create 404 Error in Firefox
 
-By default, Firefox will redirect `http` domains to `https`. If you have not [enabled https for your proxy URLs](#using-https), this will mean your proxy URLs will result in a `404 page not found` error
+By default, Firefox will redirect `http` domains to `https`. If you have not [enabled https for your proxy URLs](#using-https), this will mean your proxy URLs will result in a `404 page not found` error.
 
 To fix this, either enable https for your Lando proxy urls, or disable HTTPS-Only Mode in Firefox following the steps under [Add exceptions for HTTP websites when you’re in HTTPS-Only Mode](https://support.mozilla.org/en-US/kb/https-only-prefs#w_add-exceptions-for-http-websites-when-youre-in-https-only-mode).
 


### PR DESCRIPTION
By default, Firefox will redirect `http` domains to `https`, which can result in a `404 page not found error` for proxy URLs.

### Extra tasks
- [x] Add a link to this detailed instruction on https://docs.lando.dev/lando-101/lando-proxy.html ?

I created https://github.com/lando/docs/pull/223.