### PR TITLE
fix: Make axios prefer IPv4 addresses

### DIFF
--- a/lib/scan.js
+++ b/lib/scan.js
@@ -2,6 +2,7 @@
 
 // Modules
 const _ = require('lodash');
+const http = require('http');
 const https = require('https');
 const Log = require('./logger');
 const Promise = require('./promise');
@@ -15,7 +16,11 @@ const requestClient = () => {
   const axios = require('axios');
   // @todo: is it ok to turn redirects off here?
   // if we don't we get an error every time http tries to redirect to https
-  return axios.create({maxRedirects: 0, httpsAgent: new https.Agent({rejectUnauthorized: false})});
+  return axios.create({
+    maxRedirects: 0,
+    httpsAgent: new https.Agent({rejectUnauthorized: false, family: 4}),
+    httpAgent: new http.Agent({family: 4}),
+  });
 };
 
 // We make this module into a function so we can pass in a logger


### PR DESCRIPTION
This PR fixes the issue outlined in #21 by making `axios` prefer IPv4 addresses when the hostname resolves to both IPv4 and IPv6.

Fixes: #21