### PR TITLE
fix(compose): Fix compose file path resolution as it is copied into the lando config directory

### DIFF
--- a/.github/workflows/build-util-images.yml
+++ b/.github/workflows/build-util-images.yml
@@ -38,6 +38,7 @@ jobs:
         run: echo "tag-suffix=-edge" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -47,7 +48,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: devwithlando/${{ matrix.image }}:${{ matrix.tag }}${{ steps.pr.outputs.tag-suffix }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/pr-core-tests.yml
+++ b/.github/workflows/pr-core-tests.yml
@@ -72,12 +72,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.DEPLOY_KEY }}
-          known_hosts: unnecessary
-          if_key_exists: replace
+      #- name: Install SSH key
+      #  uses: shimataro/ssh-key-action@v2
+      #  with:
+      #    key: ${{ secrets.DEPLOY_KEY }}
+      #    known_hosts: unnecessary
+      #    if_key_exists: replace
       - name: Install node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/builders/_init.js
+++ b/builders/_init.js
@@ -13,6 +13,8 @@ module.exports = {
     version: 'custom',
     type: 'init',
     name: 'init',
+    data: null,
+    dataHome: null,
   },
   builder: (parent, config) => class LandoInit extends parent {
     constructor(userConfRoot, home, app, env = {}, labels = {}, image = 'devwithlando/util:4') {

--- a/builders/_lando-compose.js
+++ b/builders/_lando-compose.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  name: '_lando-compose',
+  parent: '_lando',
+  builder: (parent, config) => class LandoComposeServiceV3 extends parent {
+    constructor(id, options = {}) {
+      super(id, options);
+    };
+  },
+};

--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -183,6 +183,7 @@ module.exports = {
       info.meUser = meUser;
       info.hasCerts = ssl;
       info.api = 3;
+      info.appMount = appMount;
 
       // Add the healthcheck if it exists
       if (healthcheck) info.healthcheck = healthcheck;

--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -86,6 +86,7 @@ module.exports = {
         LANDO_WEBROOT_USER: meUser,
         LANDO_WEBROOT_GROUP: meUser,
         LANDO_MOUNT: appMount,
+        LANDO_SERVICE_API: 3,
       };
 
       // Handle labels

--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -48,6 +48,8 @@ module.exports = {
         supportedIgnore = false,
         root = '',
         webroot = '/app',
+        _app = null,
+        appMount = '/app',
       } = {},
       ...sources
     ) {
@@ -81,6 +83,9 @@ module.exports = {
       const environment = {
         LANDO_SERVICE_NAME: name,
         LANDO_SERVICE_TYPE: type,
+        LANDO_WEBROOT_USER: meUser,
+        LANDO_WEBROOT_GROUP: meUser,
+        LANDO_MOUNT: appMount,
       };
 
       // Handle labels
@@ -96,7 +101,6 @@ module.exports = {
         `${userConfRoot}:/lando:cached`,
         `${scriptsDir}:/helpers`,
         `${entrypointScript}:/lando-entrypoint.sh`,
-        `${dataHome}:/var/www`,
       ];
 
       // Handle ssl
@@ -115,7 +119,7 @@ module.exports = {
       }
 
       // Add in some more dirz if it makes sense
-      if (home) volumes.push(`${home}:/user:cached`);
+      if (home && _.get(_app, 'config.keys', true)) volumes.push(`${path.join(home, '.ssh')}:/user/.ssh`);
 
       // Handle cert refresh
       // @TODO: this might only be relevant to the proxy, if so let's move it there
@@ -139,9 +143,16 @@ module.exports = {
 
       // Add named volumes and other thingz into our primary service
       const namedVols = {};
-      _.set(namedVols, data, {});
-      _.set(namedVols, dataHome, {});
-
+      if (null !== data) {
+        _.set(namedVols, data, {});
+      }
+      if (null !== dataHome) {
+        _.set(namedVols, dataHome, {});
+        volumes.push(`${dataHome}:/var/www`);
+      }
+      if (null === entrypoint) {
+        entrypoint = undefined;
+      }
       sources.push({
         services: _.set({}, name, {
           entrypoint,

--- a/examples/build/.lando.yml
+++ b/examples/build/.lando.yml
@@ -14,7 +14,7 @@ events:
     - cat /var/www/run_internal.txt | grep www-data
     - cat /run_as_root.txt | grep root
     - cat /var/www/run.txt | grep www-data
-    - /bin/sh -c 'echo "$LANDO_APP_PROJECT" | grep landobuild'
+    - /bin/sh -c 'echo "$LANDO_APP_PROJECT" | grep lando-build'
     # uncomment below to test out https://github.com/lando/core/issues/70
     # this is commented out by default because of https://github.com/actions/runner/issues/241
     # - bash /app/post-start.bash

--- a/examples/build/README.md
+++ b/examples/build/README.md
@@ -36,8 +36,8 @@ lando rebuild -y
 # Should rerun build steps even if containers are manually removed and stuff
 lando destroy -y
 lando start -y
-docker rm -f landobuild_nginx_1
-docker rm -f landobuild_appserver_1
+docker rm -f lando-build-nginx-1
+docker rm -f lando-build-appserver-1
 lando start -y
 lando exec appserver -- vim --version
 lando exec appserver -- cat /var/www/build.txt

--- a/examples/certs/README.md
+++ b/examples/certs/README.md
@@ -20,8 +20,8 @@ Run the following commands to verify things work as expected
 
 ```bash
 # Should set the environment variables correctly
-lando exec web -- env | grep LANDO_SERVICE_CERT | grep /lando/certs/web.landocerts.crt
-lando exec web -- env | grep LANDO_SERVICE_KEY | grep /lando/certs/web.landocerts.key
+lando exec web -- env | grep LANDO_SERVICE_CERT | grep /lando/certs/web.lando-certs.crt
+lando exec web -- env | grep LANDO_SERVICE_KEY | grep /lando/certs/web.lando-certs.key
 lando exec web2 -- env | grep LANDO_SERVICE_CERT | grep /etc/lando/certs/cert.crt
 lando exec web2 -- env | grep LANDO_SERVICE_KEY | grep /etc/lando/certs/cert.key
 lando exec web3 -- env | grep LANDO_SERVICE_CERT | grep /certs/cert.crt
@@ -70,21 +70,21 @@ lando certinfo --service web4 | grep Issuer | grep "Lando Development CA"
 
 # Should have the correct cert SANS
 lando certinfo | grep DNS | grep -w localhost
-lando certinfo | grep DNS | grep -w web.landocerts.internal
+lando certinfo | grep DNS | grep -w web.lando-certs.internal
 lando certinfo | grep DNS | grep -w web
 lando certinfo | grep "IP Address" | grep 127.0.0.1
 lando certinfo --service web2 | grep DNS | grep -w localhost
 lando certinfo --service web2 | grep DNS | grep -w web2.lndo.site
-lando certinfo --service web2 | grep DNS | grep -w web2.landocerts.internal
+lando certinfo --service web2 | grep DNS | grep -w web2.lando-certs.internal
 lando certinfo --service web2 | grep DNS | grep -w web2
 lando certinfo --service web2 | grep "IP Address" | grep 127.0.0.1
 lando certinfo --service web3 | grep DNS | grep -w vibes.rising
 lando certinfo --service web3 | grep DNS | grep -w localhost
-lando certinfo --service web3 | grep DNS | grep -w web3.landocerts.internal
+lando certinfo --service web3 | grep DNS | grep -w web3.lando-certs.internal
 lando certinfo --service web3 | grep DNS | grep -w web3
 lando certinfo --service web3 | grep "IP Address" | grep 127.0.0.1
 lando certinfo --service web4 | grep DNS | grep -w localhost
-lando certinfo --service web4 | grep DNS | grep -w web4.landocerts.internal
+lando certinfo --service web4 | grep DNS | grep -w web4.lando-certs.internal
 lando certinfo --service web4 | grep DNS | grep -w web4
 lando certinfo --service web4 | grep "IP Address" | grep 127.0.0.1
 

--- a/examples/events/.lando.yml
+++ b/examples/events/.lando.yml
@@ -25,6 +25,8 @@ services:
       SERVICE: web2
     ports:
       - 8080/http
+  alpine:
+    meUser: root
 
 events:
   pre-start:

--- a/examples/events/.lando.yml
+++ b/examples/events/.lando.yml
@@ -25,8 +25,6 @@ services:
       SERVICE: web2
     ports:
       - 8080/http
-  alpine:
-    meUser: root
 
 events:
   pre-start:

--- a/examples/events/README.md
+++ b/examples/events/README.md
@@ -49,7 +49,8 @@ lando what-service --service web2 | grep web | wc -l | grep 2
 lando multi-pass
 
 # Should run on rebuild without failing and trigger pre-rebuild event
-lando rebuild -y | grep "ET TU, BRUT"
+lando rebuild -y || lando logs -s appserver
+echo "Test" | grep "Nope"
 lando ssh -s web -c "cat /app/test/web-pre-rebuild.txt | grep rebuilding"
 lando ssh -s l337 -c "cat /app/test/l337-pre-rebuild.txt | grep rebuilding"
 lando exec web2 -- cat /app/test/web2-pre-rebuild.txt | grep rebuilding

--- a/examples/events/compose.yml
+++ b/examples/events/compose.yml
@@ -1,12 +1,17 @@
 services:
   appserver:
     image: php:7.1-fpm-alpine
+    entrypoint: /helpers/lando-entrypoint.sh
+    command: php-fpm
     environment:
       SERVICE: 'appserver'
   web:
     image: nginx
+    entrypoint: /helpers/lando-entrypoint.sh
+    command: nginx -g daemon off
     environment:
       SERVICE: 'web'
   alpine:
     image: alpine
+    entrypoint: /helpers/lando-entrypoint.sh
     command: tail -f /dev/null

--- a/examples/info/README.md
+++ b/examples/info/README.md
@@ -38,7 +38,7 @@ lando info --deep --format json | grep "^\[{\""
 
 # Should output tabular data with --format table
 lando info --format table | grep Key | grep Value
-lando info --deep --format table | grep NetworkSettings.Networks.lando_bridge_network.Aliases | grep web4.landoinfo.internal
+lando info --deep --format table | grep NetworkSettings.Networks.lando_bridge_network.Aliases | grep web4.lando-info.internal
 
 # Should return a specified --path when given with lando info
 lando info --path "[0]" | grep service | wc -l | grep 1
@@ -59,7 +59,7 @@ lando destroy -y
 lando info --service web --path urls | grep "\[\]"
 lando info --service web --path type | grep docker-compose
 lando info --service web --path healthy | grep unknown
-lando info --service web --path hostnames | grep web.landoinfo.internal
+lando info --service web --path hostnames | grep web.lando-info.internal
 lando info --service web2 --path urls | grep "\[\]"
 lando info --service web2 --path type | grep lando
 lando info --service web2 --path healthy | grep unknown
@@ -67,7 +67,7 @@ lando info --service web2 --path version | grep custom
 lando info --service web2 --path meUser | grep www-data
 lando info --service web2 --path hasCerts | grep "false"
 lando info --service web2 --path api | grep 3
-lando info --service web2 --path hostnames | grep web2.landoinfo.internal
+lando info --service web2 --path hostnames | grep web2.lando-info.internal
 lando info --service web3 --path urls | grep "\[\]"
 lando info --service web3 --path type | grep l337
 lando info --service web3 --path healthy | grep unknown
@@ -77,7 +77,7 @@ lando info --service web3 --path primary | grep "true"
 lando info --service web3 --path image | grep nginx
 lando info --service web3 --path user | grep root
 lando info --service web3 --path appMount | grep /usr/share/nginx/html
-lando info --service web3 --path hostnames | grep web3.landoinfo.internal
+lando info --service web3 --path hostnames | grep web3.lando-info.internal
 lando info --service web4 --path urls | grep "\[\]"
 lando info --service web4 --path type | grep lando
 lando info --service web4 --path healthy | grep unknown
@@ -88,14 +88,14 @@ lando info --service web4 --path primary | grep "false"
 lando info --service web4 --path image | grep nginxinc/nginx-unprivileged:1.26.1
 lando info --service web4 --path user | grep nginx
 lando info --service web4 --path appMount | grep /usr/share/nginx/html
-lando info --service web4 --path hostnames | grep web4.landoinfo.internal
+lando info --service web4 --path hostnames | grep web4.lando-info.internal
 
 # Should have the correct info after a start and/or rebuild
 lando start
 lando info --service web --path urls | grep "\[\]"
 lando info --service web --path type | grep docker-compose
 lando info --service web --path healthy | grep unknown
-lando info --service web --path hostnames | grep web.landoinfo.internal
+lando info --service web --path hostnames | grep web.lando-info.internal
 lando info --service web2 --path urls | grep "http://localhost"
 lando info --service web2 --path type | grep lando
 lando info --service web2 --path healthy | grep unknown
@@ -103,7 +103,7 @@ lando info --service web2 --path version | grep custom
 lando info --service web2 --path meUser | grep www-data
 lando info --service web2 --path hasCerts | grep "false"
 lando info --service web2 --path api | grep 3
-lando info --service web2 --path hostnames | grep web2.landoinfo.internal
+lando info --service web2 --path hostnames | grep web2.lando-info.internal
 lando info --service web3 --path urls | grep "http://localhost"
 lando info --service web3 --path type | grep l337
 lando info --service web3 --path healthy | grep unknown
@@ -114,7 +114,7 @@ lando info --service web3 --path primary | grep "true"
 lando info --service web3 --path image | grep nginx
 lando info --service web3 --path user | grep root
 lando info --service web3 --path appMount | grep /usr/share/nginx/html
-lando info --service web3 --path hostnames | grep web3.landoinfo.internal
+lando info --service web3 --path hostnames | grep web3.lando-info.internal
 lando info --service web4 --path urls | grep "http://localhost"
 lando info --service web4 --path type | grep lando
 lando info --service web4 --path healthy | grep unknown
@@ -126,12 +126,12 @@ lando info --service web4 --path primary | grep "false"
 lando info --service web4 --path image | grep nginxinc/nginx-unprivileged:1.26.1
 lando info --service web4 --path user | grep nginx
 lando info --service web4 --path appMount | grep /usr/share/nginx/html
-lando info --service web4 --path hostnames | grep web4.landoinfo.internal
+lando info --service web4 --path hostnames | grep web4.lando-info.internal
 lando rebuild -y
 lando info --service web --path urls | grep "\[\]"
 lando info --service web --path type | grep docker-compose
 lando info --service web --path healthy | grep unknown
-lando info --service web --path hostnames | grep web.landoinfo.internal
+lando info --service web --path hostnames | grep web.lando-info.internal
 lando info --service web2 --path urls | grep "http://localhost"
 lando info --service web2 --path type | grep lando
 lando info --service web2 --path healthy | grep unknown
@@ -139,7 +139,7 @@ lando info --service web2 --path version | grep custom
 lando info --service web2 --path meUser | grep www-data
 lando info --service web2 --path hasCerts | grep "false"
 lando info --service web2 --path api | grep 3
-lando info --service web2 --path hostnames | grep web2.landoinfo.internal
+lando info --service web2 --path hostnames | grep web2.lando-info.internal
 lando info --service web3 --path urls | grep "http://localhost"
 lando info --service web3 --path type | grep l337
 lando info --service web3 --path healthy | grep unknown
@@ -150,7 +150,7 @@ lando info --service web3 --path primary | grep "true"
 lando info --service web3 --path image | grep nginx
 lando info --service web3 --path user | grep root
 lando info --service web3 --path appMount | grep /usr/share/nginx/html
-lando info --service web3 --path hostnames | grep web3.landoinfo.internal
+lando info --service web3 --path hostnames | grep web3.lando-info.internal
 lando info --service web4 --path urls | grep "http://localhost"
 lando info --service web4 --path type | grep lando
 lando info --service web4 --path healthy | grep unknown
@@ -162,7 +162,7 @@ lando info --service web4 --path primary | grep "false"
 lando info --service web4 --path image | grep nginxinc/nginx-unprivileged:1.26.1
 lando info --service web4 --path user | grep nginx
 lando info --service web4 --path appMount | grep /usr/share/nginx/html
-lando info --service web4 --path hostnames | grep web4.landoinfo.internal
+lando info --service web4 --path hostnames | grep web4.lando-info.internal
 ```
 
 ## Destroy tests

--- a/examples/l337/README.md
+++ b/examples/l337/README.md
@@ -85,8 +85,8 @@ lando env | grep SERVICE | grep web
 lando whoami | grep nginx
 
 # should set http/https metadata as needed
-docker inspect l337_web_1 | grep dev.lando.http-ports | grep "8888"
-docker inspect l337_web_1 | grep dev.lando.https-ports | grep '"",'
+docker inspect l337-web-1 | grep dev.lando.http-ports | grep "8888"
+docker inspect l337-web-1 | grep dev.lando.https-ports | grep '"",'
 
 # should automatically set appMount if appRoot is volume mounted
 lando pwd | grep /site

--- a/examples/lando-101/.lando.config.yml
+++ b/examples/lando-101/.lando.config.yml
@@ -2,3 +2,6 @@ name: lando-101
 recipe: lamp
 config:
   php: 7.4
+
+plugins:
+  "@lando/core": "../../.."

--- a/examples/lando-101/.lando.proxy.yml
+++ b/examples/lando-101/.lando.proxy.yml
@@ -11,3 +11,6 @@ services:
 proxy:
   mailhog:
     - mail.lando-101.lndo.site
+
+plugins:
+  "@lando/core": "../../.."

--- a/examples/lando-101/.lando.services.yml
+++ b/examples/lando-101/.lando.services.yml
@@ -8,3 +8,6 @@ services:
     portforward: true
     hogfrom:
       - appserver
+
+plugins:
+  "@lando/core": "../../.."

--- a/examples/lando-101/.lando.tooling.yml
+++ b/examples/lando-101/.lando.tooling.yml
@@ -15,3 +15,6 @@ tooling:
   phpcs:
     service: appserver
     cmd: /app/vendor/bin/phpcs
+
+plugins:
+  "@lando/core": "../../.."

--- a/examples/lando-101/.lando.yml
+++ b/examples/lando-101/.lando.yml
@@ -1,2 +1,5 @@
 name: lando-101
 recipe: lamp
+
+plugins:
+  "@lando/core": "../../.."

--- a/examples/landofile/README.md
+++ b/examples/landofile/README.md
@@ -20,17 +20,17 @@ Run the following commands to verify things work as expected
 
 ```bash
 # Should merge in all Landofiles correctly
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_log_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web2_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web3_1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-log-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web2-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web3-1
 
 # Should merge in all Landofiles correctly even if we are down a directory
 cd docker-compose
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_log_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web2_1
-docker ps --filter label=com.docker.compose.project=landolandofile | grep landolandofile_web3_1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-log-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web2-1
+docker ps --filter label=com.docker.compose.project=lando-landofile | grep lando-landofile-web3-1
 cd ..
 ```
 

--- a/examples/list/README.md
+++ b/examples/list/README.md
@@ -27,20 +27,20 @@ cd ..
 lando list
 
 # Should list this apps containers
-lando list --app landolist | grep landolist_web_1
-lando list --app landolist | grep landolist_web2_1
-lando list --app landolist | grep landolist_web3_1
-lando list --app landolist | grep landolist_web4_1
+lando list --app lando-list | grep lando-list-web-1
+lando list --app lando-list | grep lando-list-web2-1
+lando list --app lando-list | grep lando-list-web3-1
+lando list --app lando-list | grep lando-list-web4-1
 
 # Should list no containers if we spin down the app
 lando stop
 lando list | grep "\[\]"
 
 # Should list even stopped containers with --all
-lando list --all | grep landolist_web_1
-lando list --all | grep landolist_web2_1
-lando list --all | grep landolist_web3_1
-lando list --all | grep landolist_web4_1
+lando list --all | grep lando-list-web-1
+lando list --all | grep lando-list-web2-1
+lando list --all | grep lando-list-web3-1
+lando list --all | grep lando-list-web4-1
 
 # Should output JSON with --format json
 lando list --all --format json | grep "^\[{\""
@@ -54,11 +54,11 @@ skip
 
 # Should return --path without preceding index if array has size 1
 lando start
-lando list --filter app=landolist --filter service=web4 --path service | grep web4
+lando list --filter app=lando-list --filter service=web4 --path service | grep web4
 
 # Should allow data to be filtered
-docker stop landolist_web4_1
-lando list --all --filter running=false --filter app=landolist --path service | grep web4
+docker stop lando-list-web4-1
+lando list --all --filter running=false --filter app=lando-list --path service | grep web4
 ```
 
 ## Destroy tests

--- a/examples/networking/README.md
+++ b/examples/networking/README.md
@@ -34,10 +34,10 @@ Run the following commands to verify things work as expected
 ```bash
 # Should have the correct internal hostname info
 cd lamp
-lando info -s appserver | grep hostnames: | grep appserver.landolamp.internal
+lando info -s appserver | grep hostnames: | grep appserver.lando-lamp.internal
 cd .. && cd lemp
-lando info -s appserver | grep hostnames: | grep appserver.landolemp.internal
-lando info -s appserver_nginx | grep hostnames: | grep appserver_nginx.landolemp.internal
+lando info -s appserver | grep hostnames: | grep appserver.lando-lemp.internal
+lando info -s appserver_nginx | grep hostnames: | grep appserver_nginx.lando-lemp.internal
 
 # Should be able to self connect from lamp
 cd lamp
@@ -52,20 +52,20 @@ lando exec appserver_nginx -- curl https://localhost:8443
 # Should be able to curl lemp from lamp at proxy addresses and internal hostnames
 cd lamp
 lando exec appserver -- curl http://lando-lemp.lndo.site
-lando exec appserver -- curl http://appserver_nginx.landolemp.internal:8080
+lando exec appserver -- curl http://appserver_nginx.lando-lemp.internal:8080
 lando exec appserver -- curl https://lando-lemp.lndo.site
-lando exec appserver -- curl https://appserver_nginx.landolemp.internal:8443
+lando exec appserver -- curl https://appserver_nginx.lando-lemp.internal:8443
 
 # Should be able to curl lamp from lemp at proxy addresses and internal hostname
 cd lemp
 lando exec appserver_nginx -- curl http://lando-lamp.lndo.site
-lando exec appserver_nginx -- curl http://appserver.landolamp.internal
+lando exec appserver_nginx -- curl http://appserver.lando-lamp.internal
 lando exec appserver_nginx -- curl https://lando-lamp.lndo.site
-lando exec appserver_nginx -- curl https://appserver.landolamp.internal
+lando exec appserver_nginx -- curl https://appserver.lando-lamp.internal
 
 # Should even be able to connect to a database in a different app
 cd lamp
-lando exec database -- mysql -uroot -h database.landolemp.internal -e "quit"
+lando exec database -- mysql -uroot -h database.lando-lemp.internal -e "quit"
 ```
 
 Destroy tests

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -34,16 +34,16 @@ curl -s -o /dev/null -I -w "%{http_code}" http://l337.lndo.site | grep 200
 curl -s -o /dev/null -I -w "%{http_code}" http://lando4.lndo.site | grep 200
 
 # Should only work over http unless service has certs to use
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' landoproxy_web_1 | grep -w http
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' landoproxy_web_1 | grep -w "true" || echo $? | grep 1
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' landoproxy_web3_1 | grep -w "http,https"
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' landoproxy_web3_1 | grep -w "true"
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' landoproxy_l337_1 | grep -w http
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' landoproxy_l337_1 | grep -w "true" || echo $? | grep 1
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' landoproxy_web5_1 | grep -w http
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' landoproxy_web5_1 | grep -w "true" || echo $? | grep 1
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' landoproxy_web4_1 | grep -w "http,https"
-docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' landoproxy_web4_1 | grep -w "true"
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' lando-proxy-web-1 | grep -w http
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' lando-proxy-web-1 | grep -w "true" || echo $? | grep 1
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' lando-proxy-web3-1 | grep -w "http,https"
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' lando-proxy-web3-1 | grep -w "true"
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' lando-proxy-l337-1 | grep -w http
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' lando-proxy-l337-1 | grep -w "true" || echo $? | grep 1
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' lando-proxy-web5-1 | grep -w http
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' lando-proxy-web5-1 | grep -w "true" || echo $? | grep 1
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.protocols" }}' lando-proxy-web4-1 | grep -w "http,https"
+docker inspect --format='{{ index .Config.Labels "dev.lando.proxy.has-certs" }}' lando-proxy-web4-1 | grep -w "true"
 
 # Should also work over https if ssl is true and we have certs
 curl -s -o /dev/null -Ik -w "%{http_code}" https://web3.lndo.site | grep 200

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -94,12 +94,12 @@ curl http://object-format.lndo.site | grep X-Lando-Test-Ssl || echo $? | grep 1
 curl -k https://object-format.lndo.site | grep X-Lando-Test-Ssl | grep on
 
 # Should generate a default certs config file and put it in the right place
-docker exec landoproxyhyperion5000gandalfedition_proxy_1 cat /proxy_config/default-certs.yaml | grep certFile | grep /certs/cert.crt
-docker exec landoproxyhyperion5000gandalfedition_proxy_1 cat /proxy_config/default-certs.yaml | grep keyFile | grep /certs/cert.key
+docker exec landoproxyhyperion5000gandalfedition-proxy-1 cat /proxy_config/default-certs.yaml | grep certFile | grep /certs/cert.crt
+docker exec landoproxyhyperion5000gandalfedition-proxy-1 cat /proxy_config/default-certs.yaml | grep keyFile | grep /certs/cert.key
 
 # Should generate proxy cert files and move them into the right location as needed
-docker exec landoproxy_web3_1 cat /proxy_config/web3.landoproxy.yaml| grep certFile | grep "/lando/certs/web3.landoproxy.crt"
-docker exec landoproxy_web3_1 cat /proxy_config/web3.landoproxy.yaml| grep keyFile | grep "/lando/certs/web3.landoproxy.key"
+docker exec lando-proxy-web3-1 cat /proxy_config/web3.lando-proxy.yaml| grep certFile | grep "/lando/certs/web3.lando-proxy.crt"
+docker exec lando-proxy-web3-1 cat /proxy_config/web3.lando-proxy.yaml| grep keyFile | grep "/lando/certs/web3.lando-proxy.key"
 lando exec web4 -- cat \$LANDO_SERVICE_CERT
 lando exec web4 -- env | grep LANDO_SERVICE_CERT | grep /certs/cert.crt
 lando exec web4 -- cat \$LANDO_SERVICE_KEY

--- a/examples/rebuild/README.md
+++ b/examples/rebuild/README.md
@@ -21,26 +21,26 @@ Run the following commands to verify things work as expected
 ```bash
 # Should rebuild the services without errors
 lando rebuild -y
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web2_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web3_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web4_1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web2-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web3-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web4-1
 
 # Should only rebuild the specified services
 lando rebuild -y --service web2
 lando rebuild -y -s web2
-docker ps --latest | grep landorebuild_web2_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web2_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web3_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web4_1
+docker ps --latest | grep lando-rebuild-web2-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web2-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web3-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web4-1
 lando rebuild -y --service web3
 lando rebuild -y -s web3
-docker ps --latest | grep landorebuild_web3_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web2_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web3_1
-docker ps --filter label=com.docker.compose.project=landorebuild | grep landorebuild_web4_1
+docker ps --latest | grep lando-rebuild-web3-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web2-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web3-1
+docker ps --filter label=com.docker.compose.project=lando-rebuild | grep lando-rebuild-web4-1
 
 # Should persist tooling cache between rebuilds
 lando do-i-exist | grep icachethereforeiam

--- a/examples/restart/README.md
+++ b/examples/restart/README.md
@@ -23,7 +23,7 @@ Run the following commands to verify things work as expected
 ```bash
 # Should stop the apps containers
 lando stop
-docker ps --filter label=com.docker.compose.project=landorestart -q | wc -l | grep 0
+docker ps --filter label=com.docker.compose.project=lando-restart -q | wc -l | grep 0
 
 # Should stop ALL running lando containers
 lando start
@@ -33,10 +33,10 @@ docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 0
 
 # Should restart the services without errors
 lando restart
-docker ps --filter label=com.docker.compose.project=landorestart | grep landorestart_web_1
-docker ps --filter label=com.docker.compose.project=landorestart | grep landorestart_web2_1
-docker ps --filter label=com.docker.compose.project=landorestart | grep landorestart_web3_1
-docker ps --filter label=com.docker.compose.project=landorestart | grep landorestart_web4_1
+docker ps --filter label=com.docker.compose.project=lando-restart | grep lando-restart-web-1
+docker ps --filter label=com.docker.compose.project=lando-restart | grep lando-restart-web2-1
+docker ps --filter label=com.docker.compose.project=lando-restart | grep lando-restart-web3-1
+docker ps --filter label=com.docker.compose.project=lando-restart | grep lando-restart-web4-1
 ```
 
 ## Destroy tests

--- a/examples/scanner/README.md
+++ b/examples/scanner/README.md
@@ -20,16 +20,16 @@ Run the following commands to validate things are rolling as they should.
 
 ```bash
 # Should set 80,443 in io.lando.http-ports label by default
-docker inspect landoscanner_scanme_1 | grep io.lando.http-ports | grep "80,443"
+docker inspect lando-scanner-scanme-1 | grep io.lando.http-ports | grep "80,443"
 
 # Should add an extra port to io.lando.http-ports if specified
-docker inspect landoscanner_moreports_1 | grep io.lando.http-ports | grep "80,443,8888"
-docker inspect landoscanner_l337_1 | grep dev.lando.http-ports | grep "8888"
+docker inspect lando-scanner-moreports-1 | grep io.lando.http-ports | grep "80,443,8888"
+docker inspect lando-scanner-l337-1 | grep dev.lando.http-ports | grep "8888"
 
 # Should set correct labels in Lando 4 services
-docker inspect landoscanner_web4_1 | grep io.lando.http-ports | grep "80,443"
-docker inspect landoscanner_web4_1 | grep dev.lando.http-ports | grep "8080"
-docker inspect landoscanner_web4_1 | grep dev.lando.https-ports | grep "8443"
+docker inspect lando-scanner-web4-1 | grep io.lando.http-ports | grep "80,443"
+docker inspect lando-scanner-web4-1 | grep dev.lando.http-ports | grep "8080"
+docker inspect lando-scanner-web4-1 | grep dev.lando.https-ports | grep "8443"
 ```
 
 ## Destroy tests

--- a/examples/storage/.lando.yml
+++ b/examples/storage/.lando.yml
@@ -49,7 +49,7 @@ services:
         type: image
 
       # remount for fun?
-      - source: landostorage-db-var-lib-mysql
+      - source: lando-storage-db-var-lib-mysql
         target: /var/lib/mysql-backup
   alpine:
     api: 4

--- a/examples/storage/.lando.yml
+++ b/examples/storage/.lando.yml
@@ -68,7 +68,7 @@ services:
         type: bind
 
       # or if you are clever and know the storage volume names you can remount them elsewhere
-      - source: landostorage-stuff
+      - source: lando-storage-stuff
         target: /things
       - source: lando-everywhere
         target: /universal

--- a/examples/storage/README.md
+++ b/examples/storage/README.md
@@ -22,13 +22,13 @@ Run the following commands to verify things work as expected
 ```bash
 # Should create storage volumes with names that imply the scope
 docker volume inspect lando-everywhere
-docker volume inspect landostorage-stuff
-docker volume inspect landostorage-alpine-some-cache-directory
-docker volume inspect landostorage-db-some-other-dir
-docker volume inspect landostorage-db-var-lib-mysql
-docker volume inspect landostorage-owners-someplace
-docker volume inspect landostorage-owners-someplace-free
-docker volume inspect landostorage-owners-someplace-secret
+docker volume inspect lando-storage-stuff
+docker volume inspect lando-storage-alpine-some-cache-directory
+docker volume inspect lando-storage-db-some-other-dir
+docker volume inspect lando-storage-db-var-lib-mysql
+docker volume inspect lando-storage-owners-someplace
+docker volume inspect lando-storage-owners-someplace-free
+docker volume inspect lando-storage-owners-someplace-secret
 docker volume list --filter "label=dev.lando.storage-volume=TRUE" | wc -l | grep 9
 
 # Should create storage bind mounts
@@ -39,22 +39,22 @@ docker volume inspect lando-everywhere | grep "dev.lando.storage-volume" | grep 
 docker volume inspect lando-everywhere | grep "dev.lando.storage-scope" | grep global
 docker volume inspect lando-everywhere | grep "dev.lando.storage-project" || echo "$?" | grep 1
 docker volume inspect lando-everywhere | grep "dev.lando.storage-service" || echo "$?" | grep 1
-docker volume inspect landostorage-stuff | grep "dev.lando.storage-volume" | grep TRUE
-docker volume inspect landostorage-stuff | grep "dev.lando.storage-scope" | grep app
-docker volume inspect landostorage-stuff | grep "dev.lando.storage-project" | grep landostorage
-docker volume inspect landostorage-stuff | grep "dev.lando.storage-service" | grep db
-docker volume inspect landostorage-alpine-some-cache-directory | grep "dev.lando.storage-volume" | grep TRUE
-docker volume inspect landostorage-alpine-some-cache-directory | grep "dev.lando.storage-scope" | grep service
-docker volume inspect landostorage-alpine-some-cache-directory | grep "dev.lando.storage-project" | grep landostorage
-docker volume inspect landostorage-alpine-some-cache-directory | grep "dev.lando.storage-service" | grep alpine
-docker volume inspect landostorage-db-some-other-dir | grep "dev.lando.storage-volume" | grep TRUE
-docker volume inspect landostorage-db-some-other-dir | grep "dev.lando.storage-scope" | grep service
-docker volume inspect landostorage-db-some-other-dir | grep "dev.lando.storage-project" | grep landostorage
-docker volume inspect landostorage-db-some-other-dir | grep "dev.lando.storage-service" | grep db
-docker volume inspect landostorage-db-var-lib-mysql | grep "dev.lando.storage-volume" | grep TRUE
-docker volume inspect landostorage-db-var-lib-mysql | grep "dev.lando.storage-scope" | grep service
-docker volume inspect landostorage-db-var-lib-mysql | grep "dev.lando.storage-project" | grep landostorage
-docker volume inspect landostorage-db-var-lib-mysql | grep "dev.lando.storage-service" | grep db
+docker volume inspect lando-storage-stuff | grep "dev.lando.storage-volume" | grep TRUE
+docker volume inspect lando-storage-stuff | grep "dev.lando.storage-scope" | grep app
+docker volume inspect lando-storage-stuff | grep "dev.lando.storage-project" | grep lando-storage
+docker volume inspect lando-storage-stuff | grep "dev.lando.storage-service" | grep db
+docker volume inspect lando-storage-alpine-some-cache-directory | grep "dev.lando.storage-volume" | grep TRUE
+docker volume inspect lando-storage-alpine-some-cache-directory | grep "dev.lando.storage-scope" | grep service
+docker volume inspect lando-storage-alpine-some-cache-directory | grep "dev.lando.storage-project" | grep lando-storage
+docker volume inspect lando-storage-alpine-some-cache-directory | grep "dev.lando.storage-service" | grep alpine
+docker volume inspect lando-storage-db-some-other-dir | grep "dev.lando.storage-volume" | grep TRUE
+docker volume inspect lando-storage-db-some-other-dir | grep "dev.lando.storage-scope" | grep service
+docker volume inspect lando-storage-db-some-other-dir | grep "dev.lando.storage-project" | grep lando-storage
+docker volume inspect lando-storage-db-some-other-dir | grep "dev.lando.storage-service" | grep db
+docker volume inspect lando-storage-db-var-lib-mysql | grep "dev.lando.storage-volume" | grep TRUE
+docker volume inspect lando-storage-db-var-lib-mysql | grep "dev.lando.storage-scope" | grep service
+docker volume inspect lando-storage-db-var-lib-mysql | grep "dev.lando.storage-project" | grep lando-storage
+docker volume inspect lando-storage-db-var-lib-mysql | grep "dev.lando.storage-service" | grep db
 
 # Should share app scoped storage volumes across all app services
 lando exec db -- touch /stuff/test1
@@ -177,10 +177,10 @@ lando exec alpine -- stat /universal/test1
 # Should not persist non-global storage volumes across rebuilds
 lando destroy -y
 docker volume inspect lando-everywhere
-docker volume inspect landostorage-stuff || echo "$?" | grep 1
-docker volume inspect landostorage-alpine-some-cache-directory || echo "$?" | grep 1
-docker volume inspect landostorage-db-some-other-dir || echo "$?" | grep 1
-docker volume inspect landostorage-db-var-lib-mysql || echo "$?" | grep 1
+docker volume inspect lando-storage-stuff || echo "$?" | grep 1
+docker volume inspect lando-storage-alpine-some-cache-directory || echo "$?" | grep 1
+docker volume inspect lando-storage-db-some-other-dir || echo "$?" | grep 1
+docker volume inspect lando-storage-db-var-lib-mysql || echo "$?" | grep 1
 docker volume list --filter "label=dev.lando.storage-volume=TRUE" | wc -l | grep 2
 lando start
 lando exec db -- mysql -u root -e "SHOW DATABASES;" | grep vibes || echo "$?" | grep 1
@@ -190,10 +190,10 @@ lando exec alpine -- stat /things/test1 || echo "$?" | grep 1
 # Should persist global storage across destroys
 lando destroy -y
 docker volume inspect lando-everywhere
-docker volume inspect landostorage-stuff || echo "$?" | grep 1
-docker volume inspect landostorage-alpine-some-cache-directory || echo "$?" | grep 1
-docker volume inspect landostorage-db-some-other-dir || echo "$?" | grep 1
-docker volume inspect landostorage-db-var-lib-mysql || echo "$?" | grep 1
+docker volume inspect lando-storage-stuff || echo "$?" | grep 1
+docker volume inspect lando-storage-alpine-some-cache-directory || echo "$?" | grep 1
+docker volume inspect lando-storage-db-some-other-dir || echo "$?" | grep 1
+docker volume inspect lando-storage-db-var-lib-mysql || echo "$?" | grep 1
 docker volume list --filter "label=dev.lando.storage-volume=TRUE" | wc -l | grep 2
 lando start
 lando exec alpine -- stat /universal/test1
@@ -227,9 +227,9 @@ lando exec owners -- stat /someplace-free/me
 
 # Should allow for top level volumes to still be used with overrides.volumes
 docker volume inspect my-data || echo "$?" | grep 1
-docker volume inspect landostorage_my-data
-docker volume inspect landostorage_my-data | grep com.docker.compose.project | grep landostorage
-docker volume inspect landostorage_my-data | grep com.docker.compose.volume | grep my-data
+docker volume inspect lando-storage_my-data
+docker volume inspect lando-storage_my-data | grep com.docker.compose.project | grep lando-storage
+docker volume inspect lando-storage_my-data | grep com.docker.compose.volume | grep my-data
 lando exec --user root db -- touch /my-data/thing
 ```
 

--- a/hooks/app-add-v3-services.js
+++ b/hooks/app-add-v3-services.js
@@ -6,6 +6,13 @@ module.exports = async (app, lando) => {
   // add parsed services to app object so we can use them downstream
   app.cachedInfo = _.get(lando.cache.get(app.composeCache), 'info', []);
   app.parsedServices = require('../utils/parse-v3-services')(_.get(app, 'config.services', {}), app);
+  app.parsedServices = app.parsedServices.concat(
+    require('../utils/parse-compose-services')(
+      _.get(app, 'config.services', {}),
+      _.keys(_.get(app, 'composeData[0].data[0].services', {})),
+      app,
+    ),
+  );
   app.parsedV3Services = _(app.parsedServices).filter(service => service.api === 3).value();
   app.servicesList = app.parsedV3Services.map(service => service.name);
 

--- a/hooks/app-run-events.js
+++ b/hooks/app-run-events.js
@@ -4,28 +4,6 @@ const _ = require('lodash');
 
 module.exports = async (app, lando, cmds, data, event) => {
   const eventCommands = require('./../utils/parse-events-config')(cmds, app, data);
-  // add perm sweeping to all v3 services
-  if (!_.isEmpty(eventCommands)) {
-    const permsweepers = _(eventCommands)
-      .filter(command => command.api === 3)
-      .map(command => ({id: command.id, services: _.get(command, 'opts.services', [])}))
-      .uniqBy('id')
-      .value();
-    lando.log.debug('added preemptive perm sweeping to evented v3 services %j', permsweepers.map(s => s.id));
-    _.forEach(permsweepers, ({id, services}) => {
-      eventCommands.unshift({
-        id,
-        cmd: '/helpers/user-perms.sh --silent',
-        compose: app.compose,
-        project: app.project,
-        opts: {
-          mode: 'attach',
-          user: 'root',
-          services,
-        },
-      });
-    });
-  }
   const injectable = _.has(app, 'engine') ? app : lando;
   return injectable.engine.run(eventCommands).catch(err => {
     const command = _.tail(event.split('-')).join('-');

--- a/hooks/app-run-events.js
+++ b/hooks/app-run-events.js
@@ -25,9 +25,11 @@ module.exports = async (app, lando, cmds, data, event) => {
       lando.exitCode = 12;
     }
   }).finally(() => {
-    const run = _.first(
-      _.filter(eventCommands, eventCommand => true === eventCommand.isInitEventCommand),
-    );
+    const initToolingRunners = _.filter(eventCommands, eventCommand => true === eventCommand.isInitEventCommand);
+    if (_.isEmpty(initToolingRunners)) {
+      return;
+    }
+    const run = _.first(initToolingRunners);
 
     run.opts = {purge: true, mode: 'attach'};
     return injectable.engine.stop(run)

--- a/lib/app.js
+++ b/lib/app.js
@@ -56,7 +56,7 @@ module.exports = class App {
      * @alias app.name
      */
     this.name = require('../utils/slugify')(name);
-    this.project = require('../utils/docker-composify')(this.name);
+    this.project = this.name;
     this._serviceApi = 3;
     this._config = lando.config;
     this._defaultService = 'appserver';
@@ -273,14 +273,23 @@ module.exports = class App {
     // We should only need to initialize once, if we have just go right to app ready
     if (this.initialized) return this.events.emit('ready', this);
     // Get compose data if we have any, otherwise set to []
-    const composeFiles = require('../utils/load-compose-files')(_.get(this, 'config.compose', []), this.root);
-    this.composeData = [new this.ComposeService('compose', {}, ...composeFiles)];
-    // Validate and set env files
-    this.envFiles = require('../utils/normalize-files')(_.get(this, 'config.env_file', []), this.root);
-    // Log some things
-    this.log.verbose('initiatilizing app at %s...', this.root);
-    this.log.silly('app has config', this.config);
-
+    return require('../utils/load-compose-files')(
+      _.get(this, 'config.compose', []),
+      this.root,
+      this._dir,
+      (composeFiles, outputFilePath) =>
+        this.engine.getComposeConfig({compose: composeFiles, project: this.project, outputFilePath}),
+    )
+    .then(composeFileData => {
+      if (undefined !== composeFileData) {
+        this.composeData = [new this.ComposeService('compose', {}, composeFileData)];
+      }
+      // Validate and set env files
+      this.envFiles = require('../utils/normalize-files')(_.get(this, 'config.env_file', []), this.root);
+      // Log some things
+      this.log.verbose('initiatilizing app at %s...', this.root);
+      this.log.silly('app has config', this.config);
+    })
     /**
      * Event that allows altering of the app object right before it is
      * initialized.
@@ -293,8 +302,9 @@ module.exports = class App {
      * @event pre_init
      * @property {App} app The app instance.
      */
-    return loadPlugins(this, this._lando).then(() => this.events.emit('pre-init', this))
+    .then(() => loadPlugins(this, this._lando))
 
+    .then(() => this.events.emit('pre-init', this))
     // Actually assemble this thing so its ready for that engine
     .then(() => {
       // Get all the services
@@ -304,7 +314,7 @@ module.exports = class App {
       // Merge whatever we have thus far together
       this.info = require('../utils/get-app-info-defaults')(this);
       // finally just make a list of containers
-      const separator = _.get(this, '_config.orchestratorSeparator', '_');
+      const separator = _.get(this, '_config.orchestratorSeparator', '-');
       this.containers = _(this.info)
         .map(service => ([service.service, `${this.project}${separator}${service.service}${separator}1`]))
         .fromPairs()

--- a/lib/app.js
+++ b/lib/app.js
@@ -6,6 +6,7 @@ const hasher = require('object-hash');
 const path = require('path');
 const Promise = require('./promise');
 const utils = require('./utils');
+const fs = require('node:fs');
 
 /*
  * Helper to init and then report
@@ -506,7 +507,19 @@ module.exports = class App {
   start() {
     // Log
     this.log.info('starting app...');
+    const shouldBootstrap = fs.existsSync(this._dir);
+
     return initAndReport(this)
+
+    /**
+     * Event that only gets triggered if the app never started before (or was destroyed)
+     *
+     * @since 3.22.3
+     * @alias app.events:bootstrap
+     * @event bootstrap
+     * @property {App} app The app instance.
+     */
+    .then(() => shouldBootstrap ? this.events.emit('bootstrap', this) : undefined)
 
     /**
      * Event that runs before an app starts up.

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -23,6 +23,19 @@ const composeFlags = {
   outputFilePath: '-o',
 };
 
+const composeFlagOptionMapping = {
+  build: ['noCache', 'pull', 'q'],
+  down: ['removeOrphans', 'volumes'],
+  exec: ['background', 'detach', 'noTTY'],
+  kill: ['removeOrphans'],
+  logs: ['follow', 'timestamps'],
+  ps: ['q'],
+  pull: ['q'],
+  rm: ['force', 'volumes'],
+  up: ['background', 'detach', 'noRecreate', 'noDeps', 'pull', 'q', 'recreate', 'removeOrphans', 'timestamps'],
+  config: ['outputFilePath', 'q'],
+};
+
 // Default options nad things
 const defaultOptions = {
   build: {noCache: false, pull: true},
@@ -40,7 +53,14 @@ const defaultOptions = {
 /*
  * Helper to merge options with default
  */
-const mergeOpts = (run, opts = {}) => _.merge({}, defaultOptions[run], opts);
+const mergeOpts = (run, opts = {}) => _.merge(
+  {},
+  defaultOptions[run],
+  _.pickBy(
+    opts,
+    (value, index) => (!_.includes(_.keys(composeFlags), index)) || _.includes(composeFlagOptionMapping[run], index),
+  ),
+);
 
 /*
  * Parse docker-compose options

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -20,6 +20,7 @@ const composeFlags = {
   rm: '--rm',
   timestamps: '--timestamps',
   volumes: '-v',
+  outputFilePath: '-o',
 };
 
 // Default options nad things
@@ -33,6 +34,7 @@ const defaultOptions = {
   pull: {},
   rm: {force: true, volumes: true},
   up: {background: true, noRecreate: true, recreate: false, removeOrphans: true},
+  config: {},
 };
 
 /*
@@ -139,6 +141,9 @@ exports.run = (compose, project, opts = {}) => {
     } else if (opts.cmd[opts.cmd.length - 1] === '&') {
       opts.cmd.pop();
       opts.detach = true;
+    } else if (opts.cmd[opts.cmd.length - 1].endsWith('&')) {
+      opts.cmd[opts.cmd.length - 1] = opts.cmd[opts.cmd.length - 1].slice(0, -1).trim();
+      opts.detach = true;
     }
   }
 
@@ -155,3 +160,8 @@ exports.start = (compose, project, opts = {}) => buildShell('up', project, compo
  * Run docker compose stop
  */
 exports.stop = (compose, project, opts = {}) => buildShell('stop', project, compose, opts);
+
+/*
+ * Run docker compose config
+ */
+exports.config = (compose, project, opts = {}) => buildShell('config', project, compose, opts);

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -46,7 +46,7 @@ const defaultOptions = {
   ps: {q: true},
   pull: {},
   rm: {force: true, volumes: true},
-  up: {background: true, noRecreate: false, recreate: false, removeOrphans: true},
+  up: {background: true, noRecreate: true, recreate: false, removeOrphans: true},
   config: {},
 };
 

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -46,7 +46,7 @@ const defaultOptions = {
   ps: {q: true},
   pull: {},
   rm: {force: true, volumes: true},
-  up: {background: true, noRecreate: true, recreate: false, removeOrphans: true},
+  up: {background: true, noRecreate: false, recreate: false, removeOrphans: true},
   config: {},
 };
 

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -92,7 +92,7 @@ module.exports = class Landerode extends Dockerode {
     // Filter by app name if an app name was given.
     .then(containers => {
       if (options.project) return _.filter(containers, c => c.app === options.project);
-      else if (options.app) return _.filter(containers, c => c.app === require('../utils/docker-composify')(options.app)); // eslint-disable-line max-len
+      else if (options.app) return _.filter(containers, c => c.app === (options.app));
       return containers;
     })
     // Then finally filter by everything else

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -69,7 +69,7 @@ module.exports = class Landerode extends Dockerode {
   /*
    * Returns a list of Lando containers
    */
-  list(options = {}, separator = '_') {
+  list(options = {}, separator = '-') {
     return this.listContainers(options)
     // Filter out nulls and undefineds.
     .filter(_.identity)

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -28,7 +28,7 @@ module.exports = class Engine {
     this.dockerInstalled = this.daemon.docker !== false;
 
     // set the compose separator
-    this.separator = _.get(config, 'orchestratorSeparator', '_');
+    this.separator = _.get(config, 'orchestratorSeparator', '-');
 
     // Grab the supported ranges for our things
     this.supportedVersions = config.dockerSupportedVersions;
@@ -487,6 +487,26 @@ module.exports = class Engine {
     else if (_.has(data, 'services') && _.get(data, 'services', []).length === 0) return Promise.resolve();
     // stop
     return this.engineCmd('stop', data);
+  };
+
+  /**
+   * Get dumped docker compose config for compose files from project
+   * using a `compose` object with `{compose: compose, project: project, opts: opts}`
+   *
+   * @since 3.0.0
+   * @param {Object} data Config needs a service within a compose context
+   * @param {Array} data.compose An Array of paths to Docker compose files
+   * @param {String} data.project A String of the project name (Usually this is the same as the app name)
+   * @param {String} [data.outputFilePath='/path/to/file.yml'] String to output path
+   * @param {Object} [data.opts] Options
+   * @return {Promise} A Promise.
+   * @example
+   * return lando.engine.stop(app);
+   */
+  getComposeConfig(data) {
+    data.opts = {cmd: ['-o', data.outputFilePath]};
+    delete data.outputFilePath;
+    return this.engineCmd('config', data);
   };
 };
 

--- a/lib/router.js
+++ b/lib/router.js
@@ -133,3 +133,5 @@ exports.start = (data, compose) => retryEach(data, datum => compose('start', dat
 exports.stop = (data, compose, docker) => retryEach(data, datum => {
   return (datum.compose) ? compose(data.kill ? 'kill' : 'stop', datum) : docker.stop(getContainerId(datum));
 });
+
+exports.config = (data, compose) => retryEach(data, datum => compose('config', datum));

--- a/lib/router.js
+++ b/lib/router.js
@@ -85,6 +85,19 @@ exports.run = (data, compose, docker, started = true) => Promise.mapSeries(norma
         // if this is a prestart build step and its not the last one make sure we set started = true
         // this prevents us from having to stop and then restart the container during builds
         started = _.get(datum, 'opts.prestart', false) && !_.get(datum, 'opts.last', false);
+
+        const cmd = [
+          '/bin/sh',
+          '-c',
+          // eslint-disable-next-line max-len
+          'if [ "$LANDO_SERVICE_API" = "3" ] && test -f /helpers/check-entrypoint-ran.sh; then /helpers/check-entrypoint-ran.sh; fi',
+        ];
+        return compose('run', _.merge(
+          {},
+          datum,
+          {opts: {cmd, id: datum.id, user: 'root', mode: 'attach'}},
+          ),
+        );
       });
     }
   })

--- a/plugins/proxy/app.js
+++ b/plugins/proxy/app.js
@@ -182,19 +182,17 @@ module.exports = (app, lando) => {
         service.labels['traefik.enable'] = true;
         service.labels['traefik.docker.network'] = lando.config.proxyNet;
         service.environment.LANDO_PROXY_PASSTHRU = _.toString(lando.config.proxyPassThru);
-        const proxyVolume = `${lando.config.proxyName}_proxy_config`;
         return {
           services: _.set({}, service.name, {
             networks: {'lando_proxyedge': {}},
             labels: service.labels,
             environment: service.environment,
             volumes: [
-              `${proxyVolume}:/proxy_config`,
+              `${lando.config.proxyConfigDir}:/proxy_config`,
               `${lando.config.userConfRoot}/scripts/proxy-certs.sh:/scripts/100-proxy-certs`,
             ],
           }),
           networks: {'lando_proxyedge': {name: lando.config.proxyNet, external: true}},
-          volumes: _.set({}, proxyVolume, {external: true}),
         };
       })
 

--- a/plugins/proxy/builders/_proxy.js
+++ b/plugins/proxy/builders/_proxy.js
@@ -6,7 +6,14 @@ const _ = require('lodash');
 /*
  * Helper to get core proxy service
  */
-const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, version = 'unknown'} = {}) => {
+const getProxy = ({
+  proxyCommand,
+  proxyPassThru,
+  proxyDomain,
+  userConfRoot,
+  proxyConfigDir,
+  version = 'unknown',
+} = {}) => {
   return {
     services: {
       proxy: {
@@ -24,7 +31,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
         volumes: [
           '/var/run/docker.sock:/var/run/docker.sock',
           `${userConfRoot}/scripts/proxy-certs.sh:/scripts/100-proxy-certs`,
-          'proxy_config:/proxy_config',
+          `${proxyConfigDir}:/proxy_config`,
         ],
       },
     },
@@ -32,9 +39,6 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
       edge: {
         driver: 'bridge',
       },
-    },
-    volumes: {
-      proxy_config: {},
     },
   };
 };

--- a/plugins/proxy/builders/_proxy.js
+++ b/plugins/proxy/builders/_proxy.js
@@ -10,7 +10,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
   return {
     services: {
       proxy: {
-        image: 'traefik:2.2.0',
+        image: 'traefik:2.10.7',
         command: proxyCommand.join(' '),
         environment: {
           LANDO_APP_PROJECT: '_lando_',
@@ -18,6 +18,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
           LANDO_PROXY_CONFIG_FILE: '/proxy_config/proxy.yaml',
           LANDO_PROXY_PASSTHRU: _.toString(proxyPassThru),
           LANDO_VERSION: version,
+          LANDO_DOMAIN: proxyDomain,
         },
         networks: ['edge'],
         volumes: [

--- a/plugins/proxy/index.js
+++ b/plugins/proxy/index.js
@@ -14,7 +14,7 @@ const defaultConfig = {
     '/entrypoint.sh',
     '--log.level=DEBUG',
     '--api.insecure=true',
-    '--api.dashboard=false',
+    '--api.dashboard=true',
     '--providers.docker=true',
     '--entrypoints.https.address=:443',
     '--entrypoints.http.address=:80',

--- a/plugins/proxy/scripts/proxy-certs.sh
+++ b/plugins/proxy/scripts/proxy-certs.sh
@@ -28,11 +28,6 @@ fi
 : ${LANDO_PROXY_KEY:="/lando/certs/${LANDO_SERVICE_NAME}.${LANDO_APP_PROJECT}.key"}
 : ${LANDO_PROXY_CONFIG_FILE:="/proxy_config/${LANDO_SERVICE_NAME}.${LANDO_APP_PROJECT}.yaml"}
 
-# Move over any global config set by lando
-if [ -d "/lando/proxy/config" ]; then
-  cp -rf /lando/proxy/config/* /proxy_config/
-fi
-
 # Bail if proxypassthru is off
 if [ "$LANDO_PROXY_PASSTHRU" != "true" ]; then
   lando_info "Proxy passthru is off so exiting..."

--- a/scripts/check-entrypoint-ran.sh
+++ b/scripts/check-entrypoint-ran.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# retry settings
+attempt=0
+delay=1
+retry=16
+
+until [ "$attempt" -ge "$retry" ]
+do
+  test -f "/tmp/lando-entrypoint-ran" && break
+  attempt=$((attempt+1))
+  sleep "$delay"
+done

--- a/scripts/lando-entrypoint.sh
+++ b/scripts/lando-entrypoint.sh
@@ -73,6 +73,8 @@ fi
 # @TODO: We should def figure out whether we can get away with running everything through exec at some point
 lando_info "Lando handing off to: $@"
 
+touch /tmp/lando-entrypoint-ran
+
 # Try to DROP DOWN to another user if we can
 if [ ! -z ${LANDO_DROP_USER+x} ]; then
   lando_debug "Running command as ${LANDO_DROP_USER}..."

--- a/scripts/user-perm-helpers.sh
+++ b/scripts/user-perm-helpers.sh
@@ -10,17 +10,10 @@ LANDO_MODULE="userperms"
 add_user() {
   local USER=$1
   local GROUP=$2
-  local UID=$3
-  local GID=$4
-  local DISTRO=$5
-  local EXTRAS="$6"
-  if [ "$DISTRO" = "alpine" ]; then
-    if ! groups | grep "$GROUP" > /dev/null 2>&1; then addgroup -g "$GID" "$GROUP" 2>/dev/null; fi
-    if ! id -u "$GROUP" > /dev/null 2>&1; then adduser -H -D -G "$GROUP" -u "$UID" "$USER" "$GROUP" 2>/dev/null; fi
-  else
-    if ! groups | grep "$GROUP" > /dev/null 2>&1; then groupadd --force --gid "$GID" "$GROUP" 2>/dev/null; fi
-    if ! id -u "$GROUP" > /dev/null 2>&1; then useradd --gid "$GID" --uid "$UID" $EXTRAS "$USER" 2>/dev/null; fi
-  fi;
+  local WEBROOT_UID=$3
+  local WEBROOT_GID=$4
+  if ! getent group | cut -d: -f1 | grep "$GROUP" > /dev/null 2>&1; then addgroup -g "$WEBROOT_GID" "$GROUP" 2>/dev/null; fi
+  if ! id -u "$USER" > /dev/null 2>&1; then adduser -H -D -G "$GROUP" -u "$WEBROOT_UID" "$USER" "$GROUP" 2>/dev/null; fi
 }
 
 # Verify user
@@ -29,12 +22,12 @@ verify_user() {
   local GROUP=$2
   local DISTRO=$3
   id -u "$USER" > /dev/null 2>&1
-  groups | grep "$GROUP" > /dev/null 2>&1
-  if [ "$DISTRO" = "alpine" ]; then
+  groups "$USER" | grep "$GROUP" > /dev/null 2>&1
+  if command -v chsh > /dev/null 2>&1 ; then
+    chsh -s /bin/bash $USER || true
+  else
     true
     # is there a chsh we can use? do we need to?
-  else
-    chsh -s /bin/bash $USER || true
   fi;
 }
 
@@ -59,11 +52,10 @@ reset_user() {
     if [ "$(id -u $USER)"  != "$HOST_UID" ]; then
       usermod -o -u "$HOST_UID" "$USER" 2>/dev/null
     fi
-    groupmod -g "$HOST_GID" "$GROUP" 2>/dev/null || true
-    if [ "$(id -u $USER)"  != "$HOST_UID" ]; then
+    groupmod -o -g "$HOST_GID" "$GROUP" 2>/dev/null || true
+    if [ "$(id -g $USER)"  != "$HOST_GID" ]; then
       usermod -g "$HOST_GID" "$USER" 2>/dev/null || true
     fi
-    usermod -a -G "$GROUP" "$USER" 2>/dev/null || true
   fi;
   # If this mapping is incorrect lets abort here
   if [ "$(id -u $USER)" != "$HOST_UID" ]; then
@@ -97,7 +89,6 @@ perm_sweep() {
   nohup find /user/.ssh -not -user $USER -execdir chown $USER:$GROUP {} \+ > /tmp/perms.out 2> /tmp/perms.err &
   nohup find /var/www -not -user $USER -execdir chown $USER:$GROUP {} \+ > /tmp/perms.out 2> /tmp/perms.err &
   nohup find /usr/local/bin -not -user $USER -execdir chown $USER:$GROUP {} \+ > /tmp/perms.out 2> /tmp/perms.err &
-  nohup chmod -R 755 /var/www >/dev/null 2>&1 &
 
   # Lets also make some /usr/locals chowned
   nohup find /usr/local/lib -not -user $USER -execdir chown $USER:$GROUP {} \+ > /tmp/perms.out 2> /tmp/perms.err &

--- a/scripts/user-perm-helpers.sh
+++ b/scripts/user-perm-helpers.sh
@@ -76,6 +76,7 @@ perm_sweep() {
   chown -R $USER:$GROUP /usr/local/bin
   chown $USER:$GROUP /var/www
   chown $USER:$GROUP /app
+  chown $USER:$GROUP /tmp
   chmod 755 /var/www
 
   # Do other dirs first if we have them

--- a/scripts/wait-for-user.sh
+++ b/scripts/wait-for-user.sh
@@ -5,6 +5,7 @@ set -e
 # user info
 user="${1:-$LANDO_WEBROOT_USER}"
 id="${2:-$LANDO_HOST_UID}"
+gid="${3:-$LANDO_HOST_GID}"
 
 # retry settings
 attempt=0
@@ -13,7 +14,7 @@ retry=25
 
 until [ "$attempt" -ge "$retry" ]
 do
-  id "$user"| grep uid | grep "$id" &>/dev/null && break
+  id -u "$user" | grep "$id" &>/dev/null && id -g "$user" | grep "$gid" &>/dev/null && break
   attempt=$((attempt+1))
   sleep "$delay"
 done

--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -127,6 +127,8 @@ module.exports = (lando, config = lando.appConfig) => ({
     ropts.push(sconf?.overrides?.working_dir ?? sconf?.working_dir);
     // mix in mount if applicable
     ropts.push(app?.mounts[options.service]);
+    ropts.push(!options.deps ?? true);
+    ropts.push(options.autoRemove ?? false);
 
     // emit pre-exec
     await app.events.emit('pre-exec', config);
@@ -137,18 +139,12 @@ module.exports = (lando, config = lando.appConfig) => ({
     // try to run it
     try {
       lando.log.debug('running exec command %o on %o', runner.cmd, runner.id);
-      await require('../utils/build-docker-exec')(lando, ['inherit', 'pipe', 'pipe'], runner);
+      await lando.engine.run(runner);
 
     // error
     } catch (error) {
-      return lando.engine.isRunning(runner.id).then(isRunning => {
-        if (!isRunning) {
-          throw new Error(`Looks like your app is stopped! ${color.bold('lando start')} it up to exec your heart out.`);
-        } else {
-          error.hide = true;
-          throw error;
-        }
-      });
+      error.hide = true;
+      throw error;
 
     // finally
     } finally {

--- a/tasks/info.js
+++ b/tasks/info.js
@@ -38,7 +38,7 @@ module.exports = lando => ({
           .map(async container => await lando.engine.scan(container))
           .filter(container => {
             if (!options.service) return true;
-            return options.service.map(service => `/${app.project}_${service}_1`).includes(container.Name);
+            return options.service.map(service => `/${app.project}-${service}-1`).includes(container.Name);
           });
 
       // normal info

--- a/tasks/ssh.js
+++ b/tasks/ssh.js
@@ -40,6 +40,7 @@ module.exports = (lando, app) => ({
         const api = _.get(_.find(app.info, {service}), 'api', 3);
         // set additional opt defaults if possible
         const opts = [undefined, api === 4 ? undefined : '/app'];
+        opts[2] = !app._config.command.deps ?? false;
         // mix any v4 service info on top of app.config.services
         const services = _(_.get(app, 'config.services', {}))
           .map((service, id) => _.merge({}, {id}, service))

--- a/tasks/ssh.js
+++ b/tasks/ssh.js
@@ -41,6 +41,7 @@ module.exports = (lando, app) => ({
         // set additional opt defaults if possible
         const opts = [undefined, api === 4 ? undefined : '/app'];
         opts[2] = !app._config.command.deps ?? false;
+        opts[3] = app._config.command.autoRemove ?? true;
         // mix any v4 service info on top of app.config.services
         const services = _(_.get(app, 'config.services', {}))
           .map((service, id) => _.merge({}, {id}, service))

--- a/test/compose.spec.js
+++ b/test/compose.spec.js
@@ -202,4 +202,16 @@ describe('compose', () => {
       expect(stopResult).to.be.an('object');
     });
   });
+
+  describe('#config', () => {
+    it('should return the correct default options when not specified');
+    it('#config should return an object.', () => {
+      const configResult = compose.config(
+        ['string1', 'string2'],
+        'my_project',
+        myOpts,
+      );
+      expect(configResult).to.be.an('object');
+    });
+  });
 });

--- a/test/get-config-defaults.spec.js
+++ b/test/get-config-defaults.spec.js
@@ -34,7 +34,7 @@ describe('get-config-defaults', () => {
     expect(_.hasIn(defaults, 'plugins')).to.equal(true);
     expect(_.hasIn(defaults, 'process')).to.equal(true);
     expect(_.hasIn(defaults, 'userConfRoot')).to.equal(true);
-    expect(_.get(defaults, 'orchestratorSeparator')).to.equal('_');
+    expect(_.get(defaults, 'orchestratorSeparator')).to.equal('-');
     expect(_.get(defaults, 'configSources')).to.be.an('array');
   });
 

--- a/test/get-user.spec.js
+++ b/test/get-user.spec.js
@@ -29,6 +29,11 @@ describe('get-user', function() {
     expect(getUser('test-service', info)).to.equal('www-data');
   });
 
+  it('should return specified user if service is a "no-api" docker-compose service and user is specified', function() {
+    const info = [{service: 'test-service', type: 'docker-compose', meUser: 'custom-user'}];
+    expect(getUser('test-service', info)).to.equal('custom-user');
+  });
+
   it('should return "www-data" if service.api is 4 but no user is specified', function() {
     const info = [{service: 'test-service', api: 4}];
     expect(getUser('test-service', info)).to.equal('www-data');

--- a/utils/build-init-runner.js
+++ b/utils/build-init-runner.js
@@ -10,5 +10,7 @@ module.exports = config => ({
     user: config.user,
     services: ['init'],
     autoRemove: config.remove,
+    workdir: config.workdir,
+    prestart: config.prestart,
   },
 });

--- a/utils/build-init-runner.js
+++ b/utils/build-init-runner.js
@@ -6,6 +6,7 @@ module.exports = config => ({
   project: config.project,
   cmd: config.cmd,
   opts: {
+    environment: require('./get-cli-env')(config.env),
     mode: 'attach',
     user: config.user,
     services: ['init'],

--- a/utils/build-tooling-runner.js
+++ b/utils/build-tooling-runner.js
@@ -20,7 +20,17 @@ const getContainerPath = (appRoot, appMount = undefined) => {
   return dir.join('/');
 };
 
-module.exports = (app, command, service, user, env = {}, dir = undefined, appMount = undefined, noDeps = false) => ({
+module.exports = (
+  app,
+  command,
+  service,
+  user,
+  env = {},
+  dir = undefined,
+  appMount = undefined,
+  noDeps = false,
+  autoRemove = true,
+) => ({
   id: getContainer(app, service),
   compose: app.compose,
   project: app.project,
@@ -32,7 +42,8 @@ module.exports = (app, command, service, user, env = {}, dir = undefined, appMou
     user: (user === null) ? require('./get-user')(service, app.info) : user,
     services: _.compact([service]),
     hijack: false,
-    autoRemove: true,
+    autoRemove,
     noDeps,
+    prestart: !autoRemove,
   }, _.identity),
 });

--- a/utils/build-tooling-runner.js
+++ b/utils/build-tooling-runner.js
@@ -20,7 +20,7 @@ const getContainerPath = (appRoot, appMount = undefined) => {
   return dir.join('/');
 };
 
-module.exports = (app, command, service, user, env = {}, dir = undefined, appMount = undefined) => ({
+module.exports = (app, command, service, user, env = {}, dir = undefined, appMount = undefined, noDeps = false) => ({
   id: getContainer(app, service),
   compose: app.compose,
   project: app.project,
@@ -33,5 +33,6 @@ module.exports = (app, command, service, user, env = {}, dir = undefined, appMou
     services: _.compact([service]),
     hijack: false,
     autoRemove: true,
+    noDeps,
   }, _.identity),
 });

--- a/utils/build-tooling-runner.js
+++ b/utils/build-tooling-runner.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const path = require('path');
 
 const getContainer = (app, service) => {
-  return app?.containers?.[service] ?? `${app.project}_${service}_1`;
+  return app?.containers?.[service] ?? `${app.project}-${service}-1`;
 };
 
 const getContainerPath = (appRoot, appMount = undefined) => {

--- a/utils/build-tooling-task.js
+++ b/utils/build-tooling-task.js
@@ -24,7 +24,9 @@ module.exports = (config, injected) => {
     // Get an interable of our commandz
     .then(() => _.map(require('./parse-tooling-config')(cmd, service, options, answers, canExec)))
     // Build run objects
-    .map(({command, service}) => require('./build-tooling-runner')(app, command, service, user, env, dir, appMount))
+    .map(
+      ({command, service}) =>
+        require('./build-tooling-runner')(app, command, service, name, user, env, dir, appMount, !answers.deps ?? false))
     // Try to run the task quickly first and then fallback to compose launch
     .each(runner => require('./build-docker-exec')(injected, stdio, runner).catch(execError => {
       return injected.engine.isRunning(runner.id).then(isRunning => {

--- a/utils/build-tooling-task.js
+++ b/utils/build-tooling-task.js
@@ -22,11 +22,13 @@ module.exports = (config, injected) => {
     // Kick off the pre event wrappers
     .then(() => app.events.emit(`pre-${eventName}`, config, answers))
     // Get an interable of our commandz
-    .then(() => _.map(require('./parse-tooling-config')(cmd, service, options, answers, canExec)))
+    .then(() => _.map(require('./parse-tooling-config')(cmd, service, name, options, answers, canExec)))
     // Build run objects
     .map(
       ({command, service}) =>
-        require('./build-tooling-runner')(app, command, service, name, user, env, dir, appMount, !answers.deps ?? false))
+        require('./build-tooling-runner')(
+          app, command, service, user, env, dir, appMount, !answers.deps ?? false, answers.autoRemove ?? true,
+        ))
     // Try to run the task quickly first and then fallback to compose launch
     .each(runner => require('./build-docker-exec')(injected, stdio, runner).catch(execError => {
       return injected.engine.isRunning(runner.id).then(isRunning => {

--- a/utils/build-tooling-task.js
+++ b/utils/build-tooling-task.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const _ = require('lodash');
+const remove = require('./remove');
+const path = require('path');
 
 module.exports = (config, injected) => {
   // Get our defaults and such
   const getToolingDefaults = require('./get-tooling-defaults');
-  const {name, app, appMount, cmd, describe, dir, env, options, service, stdio, user} = getToolingDefaults(config);
+  const {name, app, appMount, cmd, describe, dir, env, options, service, user} = getToolingDefaults(config);
 
   // add debug stuff if debuggy
   env.DEBUG = injected.debuggy ? '1' : '';
@@ -18,33 +20,53 @@ module.exports = (config, injected) => {
   // Handle dynamic services and passthrough options right away
   // Get the event name handler
   const eventName = name.split(' ')[0];
-  const run = answers => injected.Promise.try(() => (_.isEmpty(app.compose)) ? app.init() : true)
-    // Kick off the pre event wrappers
-    .then(() => app.events.emit(`pre-${eventName}`, config, answers))
-    // Get an interable of our commandz
-    .then(() => _.map(require('./parse-tooling-config')(cmd, service, name, options, answers, canExec)))
-    // Build run objects
-    .map(
-      ({command, service}) =>
-        require('./build-tooling-runner')(
-          app, command, service, user, env, dir, appMount, !answers.deps ?? false, answers.autoRemove ?? true,
-        ))
-    // Try to run the task quickly first and then fallback to compose launch
-    .each(runner => require('./build-docker-exec')(injected, stdio, runner).catch(execError => {
-      return injected.engine.isRunning(runner.id).then(isRunning => {
-        if (!isRunning) {
-          return injected.engine.run(runner).catch(composeError => {
-            composeError.hide = true;
-            throw composeError;
-          });
-        } else {
-          execError.hide = true;
-          throw execError;
+  const run = answers => {
+    let initToolingRunner = null;
+
+    return injected.Promise.try(() => (_.isEmpty(app.compose)) ? app.init() : true)
+      // Kick off the pre event wrappers
+      .then(() => app.events.emit(`pre-${eventName}`, config, answers))
+      // Get an interable of our commandz
+      .then(() => _.map(require('./parse-tooling-config')(cmd, service, name, options, answers, canExec)))
+      // Build run objects
+      .map(
+        ({command, service}) => {
+          if ('_init' === service) {
+            initToolingRunner = _.merge(
+              {},
+              require('./build-init-runner')(_.merge(
+                {},
+                require('./get-init-runner-defaults')(app._lando, {destination: app.root, name: app.project}),
+                {cmd: command, workdir: '/app', env},
+              )),
+            );
+
+            return initToolingRunner;
+          }
+
+          return require('./build-tooling-runner')(
+            app, command, service, user, env, dir, appMount, !answers?.deps ?? false, answers?.autoRemove ?? true,
+          );
+        })
+      // Try to run the task quickly first and then fallback to compose launch
+      .each(runner => injected.engine.run(runner).catch(composeError => {
+              composeError.hide = true;
+              throw composeError;
+          }),
+      )
+      // Post event
+      .then(() => app.events.emit(`post-${eventName}`, config, answers))
+      .finally(() => {
+        if (null === initToolingRunner) {
+          return;
         }
+
+        initToolingRunner.opts = {purge: true, mode: 'attach'};
+        return injected.engine.stop(initToolingRunner)
+          .then(() => injected.engine.destroy(initToolingRunner))
+          .then(() => remove(path.dirname(initToolingRunner.compose[0])));
       });
-    }))
-    // Post event
-    .then(() => app.events.emit(`post-${eventName}`, config, answers));
+  };
 
   // Return our tasks
   return {

--- a/utils/filter-v3-build-steps.js
+++ b/utils/filter-v3-build-steps.js
@@ -33,26 +33,8 @@ module.exports = (services, app, rootSteps = [], buildSteps= [], prestart = fals
       }
     });
   });
-  // Let's silent run user-perm stuff and add a "last" flag
+  // Let's add a "last" flag
   if (!_.isEmpty(build)) {
-    const permsweepers = _(build)
-      .map(command => ({id: command.id, services: _.get(command, 'opts.services', [])}))
-      .uniqBy('id')
-      .value();
-    _.forEach(permsweepers, ({id, services}) => {
-      build.unshift({
-        id,
-        cmd: '/helpers/user-perms.sh --silent',
-        compose: app.compose,
-        project: app.project,
-        opts: {
-          mode: 'attach',
-          prestart,
-          user: 'root',
-          services,
-        },
-      });
-    });
     // Denote the last step in the build if its happening before start
     const last = _.last(build);
     last.opts.last = prestart;

--- a/utils/get-app-mounts.js
+++ b/utils/get-app-mounts.js
@@ -6,7 +6,7 @@ module.exports = app => _(app.services)
   // Objectify
   .map(service => _.merge({name: service}, _.get(app, `config.services.${service}`, {})))
   // Set the default
-  .map(config => _.merge({}, config, {app_mount: _.get(config, 'app_mount', 'cached')}))
+  .map(config => _.merge({}, config, {app_mount: _.get(config, 'app_mount', app.config.app_mount || 'cached')}))
   // Filter out disabled mountes
   .filter(config => config.app_mount !== false && config.app_mount !== 'disabled')
   // Combine together

--- a/utils/get-config-defaults.js
+++ b/utils/get-config-defaults.js
@@ -18,7 +18,7 @@ const getBuildEngineVersion = () => {
 
 // Default config
 const defaultConfig = options => ({
-  orchestratorSeparator: '_',
+  orchestratorSeparator: '-',
   orchestratorVersion: '2.29.2',
   configSources: [],
   coreBase: path.resolve(__dirname, '..'),

--- a/utils/get-init-runner-defaults.js
+++ b/utils/get-init-runner-defaults.js
@@ -26,5 +26,7 @@ module.exports = (lando, options) => {
     user: 'www-data',
     compose: initFiles,
     remove: false,
+    workdir: '/',
+    prestart: true,
   };
 };

--- a/utils/get-init-runner-defaults.js
+++ b/utils/get-init-runner-defaults.js
@@ -28,5 +28,6 @@ module.exports = (lando, options) => {
     remove: false,
     workdir: '/',
     prestart: true,
+    env: {},
   };
 };

--- a/utils/get-tooling-defaults.js
+++ b/utils/get-tooling-defaults.js
@@ -12,7 +12,6 @@ module.exports = ({
   env = {},
   options = {},
   service = '',
-  stdio = ['inherit', 'pipe', 'pipe'],
   user = null,
   } = {}) =>
   ({
@@ -25,6 +24,5 @@ module.exports = ({
     describe: description,
     options: options,
     service: service,
-    stdio: stdio,
     user,
   });

--- a/utils/get-user.js
+++ b/utils/get-user.js
@@ -7,8 +7,8 @@ module.exports = (name, info = []) => {
   if (!_.find(info, {service: name})) return 'www-data';
   // otherwise get the service
   const service = _.find(info, {service: name});
-  // if this is a "no-api" service eg type "docker-compose" also return www-data
-  if (!service.api && service.type === 'docker-compose') return 'www-data';
+  // if this is a "no-api" service eg type "docker-compose" return meUser or www-data as default
+  if (!service.api && service.type === 'docker-compose') return service.meUser || 'www-data';
   // otherwise return different things based on the api
   return service.api === 4 ? service.user || 'www-data' : service.meUser || 'www-data';
 };

--- a/utils/load-compose-files.js
+++ b/utils/load-compose-files.js
@@ -9,10 +9,16 @@ const remove = require('./remove');
 
 // This just runs `docker compose --project-directory ${dir} config -f ${files} --output ${outputPaths}` to
 // make all paths relative to the lando config root
-module.exports = async (files, dir, landoComposeConfigDir, outputConfigFunction) => {
+module.exports = async (files, dir, landoComposeConfigDir = undefined, outputConfigFunction = undefined) => {
   const composeFilePaths = _(require('./normalize-files')(files, dir)).value();
   if (_.isEmpty(composeFilePaths)) {
     return {};
+  }
+
+  if (undefined === outputConfigFunction) {
+    return _(composeFilePaths)
+      .map(file => yaml.load(file))
+      .value();
   }
 
   const outputFile = path.join(landoComposeConfigDir, 'resolved-compose-config.yml');

--- a/utils/load-compose-files.js
+++ b/utils/load-compose-files.js
@@ -2,8 +2,26 @@
 
 const _ = require('lodash');
 const Yaml = require('./../lib/yaml');
+const path = require('path');
 const yaml = new Yaml();
+const fs = require('fs');
+const remove = require('./remove');
 
-module.exports = (files, dir) => _(require('./normalize-files')(files, dir))
-  .map(file => yaml.load(file))
-  .value();
+// This just runs `docker compose --project-directory ${dir} config -f ${files} --output ${outputPaths}` to
+// make all paths relative to the lando config root
+module.exports = async (files, dir, landoComposeConfigDir, outputConfigFunction) => {
+  const composeFilePaths = _(require('./normalize-files')(files, dir)).value();
+  if (_.isEmpty(composeFilePaths)) {
+    return {};
+  }
+
+  const outputFile = path.join(landoComposeConfigDir, 'resolved-compose-config.yml');
+
+  fs.mkdirSync(path.dirname(outputFile), {recursive: true});
+  await outputConfigFunction(composeFilePaths, outputFile);
+  const result = yaml.load(outputFile);
+  fs.unlinkSync(outputFile);
+  remove(path.dirname(outputFile));
+
+  return result;
+};

--- a/utils/parse-compose-services.js
+++ b/utils/parse-compose-services.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Modules
+const _ = require('lodash');
+
+// adds required methods to ensure the lando v3 debugger can be injected into v4 things
+module.exports = (config, composeServiceIds, app) => _(config)
+  // Arrayify
+  .map((service, name) => _.merge({}, service, {name}))
+  // Filter out any services which are not defined in the docker compose services
+  .filter(service => _.includes(composeServiceIds, service.name))
+  // Build the config and ensure api is set to 3
+  .map(service => _.merge({}, service, {
+    _app: app,
+    app: app.name,
+    home: app.config.home || app._config.home,
+    project: app.project,
+    root: app.root,
+    type: '_lando-compose',
+    userConfRoot: app._config.userConfRoot,
+    version: 'custom',
+    api: 3,
+    entrypoint: null, // NOTE: Do not overwrite the entrypoint from docker compose. Or should we?
+    data: null, // NOTE: Do not create the data volume
+    dataHome: null, // NOTE: Do not create the dataHome volume
+  }))
+  .value();

--- a/utils/parse-events-config.js
+++ b/utils/parse-events-config.js
@@ -34,7 +34,7 @@ const getService = (cmd, data = {}, defaultService = 'appserver') => {
 };
 
 // adds required methods to ensure the lando v3 debugger can be injected into v4 things
-module.exports = (cmds, app, data = {}) => _.map(cmds, cmd => {
+module.exports = (cmds, app, data, lando) => _.map(cmds, cmd => {
   // Discover the service
   const command = getCommand(cmd);
   const service = getService(cmd, data, app._defaultService);
@@ -60,6 +60,18 @@ module.exports = (cmds, app, data = {}) => _.map(cmds, cmd => {
     cmd = ['/etc/lando/exec.sh', 'sh', '-c', _.isArray(command) ? command.join(' ') : command];
   } else {
     cmd = ['/bin/sh', '-c', _.isArray(command) ? command.join(' ') : command];
+  }
+
+  if ('_init' === service) {
+    return _.merge(
+      {},
+        require('./build-init-runner')(_.merge(
+        {},
+        require('./get-init-runner-defaults')(lando, {destination: app.root, name: app.project}),
+        {cmd, workdir: '/app'},
+      )),
+      {isInitEventCommand: true},
+    );
   }
 
   // Validate the service if we can

--- a/utils/parse-tooling-config.js
+++ b/utils/parse-tooling-config.js
@@ -40,9 +40,9 @@ const handleDynamic = (config, options = {}, answers = {}, execs = {}) => {
  * the first three assuming they are [node, lando.js, options.name]'
  * Check to see if we have global lando opts and remove them if we do
  */
-const handleOpts = (config, argopts = []) => {
+const handleOpts = (config, name, argopts = []) => {
   // Append any user specificed opts
-  argopts = argopts.concat(process.argv.slice(3));
+  argopts = argopts.concat(process.argv.slice(process.argv.findIndex(value => value === name) + 1));
   // If we have no args then just return right away
   if (_.isEmpty(argopts)) return config;
   // Return
@@ -68,13 +68,13 @@ const parseCommand = (cmd, service, execs) => ({
 });
 
 // adds required methods to ensure the lando v3 debugger can be injected into v4 things
-module.exports = (cmd, service, options = {}, answers = {}, execs = {}) => _(cmd)
+module.exports = (cmd, service, name, options = {}, answers = {}, execs = {}) => _(cmd)
   // Put into an object so we can handle "multi-service" tooling
   .map(cmd => parseCommand(cmd, service, execs))
   // Handle dynamic services
   .map(config => handleDynamic(config, options, answers, execs))
   // Add in any argv extras if they've been passed in
-  .map(config => handleOpts(config, handlePassthruOpts(options, answers)))
+  .map(config => handleOpts(config, name, handlePassthruOpts(options, answers)))
   // Wrap the command in /bin/sh if that makes sense
   .map(config => _.merge({}, config, {command: require('./shell-escape')(config.command, true, config.args, config.exec)})) // eslint-disable-line max-len
   // Add any args to the command and compact to remove undefined

--- a/utils/parse-tooling-config.js
+++ b/utils/parse-tooling-config.js
@@ -42,7 +42,7 @@ const handleDynamic = (config, options = {}, answers = {}, execs = {}) => {
  */
 const handleOpts = (config, name, argopts = []) => {
   // Append any user specificed opts
-  argopts = argopts.concat(process.argv.slice(process.argv.findIndex(value => value === name) + 1));
+  argopts = argopts.concat(process.argv.slice(process.argv.findIndex(value => value === name.split(' ')[0]) + 1));
   // If we have no args then just return right away
   if (_.isEmpty(argopts)) return config;
   // Return

--- a/utils/parse-v3-services.js
+++ b/utils/parse-v3-services.js
@@ -20,7 +20,7 @@ module.exports = (config, app) => _(config)
     app: app.name,
     confDest: path.join(app._config.userConfRoot, 'config', service.type.split(':')[0]),
     data: `data_${service.name}`,
-    home: app._config.home,
+    home: app.config.home || app._config.home,
     project: app.project,
     root: app.root,
     type: service.type.split(':')[0],

--- a/utils/run-init.js
+++ b/utils/run-init.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const remove = require('../utils/remove');
+const path = require('path');
+
 // Helper to kill a run
 const killRun = config => ({
   id: config.id,
@@ -13,7 +16,9 @@ const killRun = config => ({
 
 // adds required methods to ensure the lando v3 debugger can be injected into v4 things
 module.exports = (lando, run) => lando.engine.run(run).catch(err => {
+  return lando.Promise.reject(err);
+}).finally(() => {
   return lando.engine.stop(killRun(run))
   .then(() => lando.engine.destroy(killRun(run)))
-  .then(() => lando.Promise.reject(err));
+  .then(() => remove(path.dirname(run.compose[0])));
 });


### PR DESCRIPTION
Hey there,
to work with lando as a drop in replacement for docker-compose and the "compose" config feature, the paths to env_files, volume definitions and build contexts need to be resolved correctly. As the docker compose files get copied into the lando compose config directory, these paths change from the compose project directory. This pull request aims to resolve issue 3373, which explains this issue.
It creates a new docker compose routing method to use the docker compose config command to generate the config relative to the target directory (lando-dir/compose/project-name), so that every docker compose stack just works with lando (for an example, see [this commit](https://github.com/florianPat/symfony-demo/commit/747175ffce73f8576747f00ca094b1fe27585996#diff-307b4548b91e997f23c35d90ed5e9a044e156b90425c9923d6b85d7dc11e67e2).
Moreover, the app_mount can be disabled globally for every service due to a top level app_mount config, and one does not have to disable it for every service.

I would love some feedback on this feature.

Thanks in advance,
Flo