### PR TITLE
Fix typo in docs/development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,11 +1,11 @@
 ---
 title: Development
-description: Learn how to develop and contribute to Lando Core 
+description: Learn how to develop and contribute to Lando Core
 ---
 
 # Development
 
-This guide contains information to help onboard developers to work on Lando Core. 
+This guide contains information to help onboard developers to work on Lando Core.
 
 ## Requirements
 
@@ -17,7 +17,7 @@ At the very least you will need to have the following installed:
 
 ## Installation
 
-Working on Lando Core requires that you have both the [Lando CLI](https://github.com/lando/cli) and [Lando Core][(](https://github.com/lando/core)) installed [from source](https://docs.lando.dev/install/source.html). You can then symlink (or use `npm link`) to have `@lando/cli` utilize your locally installed source copy of `@lando/core`:
+Working on Lando Core requires that you have both the [Lando CLI](https://github.com/lando/cli) and [Lando Core](https://github.com/lando/core) installed [from source](https://docs.lando.dev/install/source.html). You can then symlink (or use `npm link`) to have `@lando/cli` utilize your locally installed source copy of `@lando/core`:
 
 
 ```sh


### PR DESCRIPTION
Fix the link to lando/core. Also remove some stray spaces at the ends of lines