### PR TITLE
lando/docs#265: Improve Windows install instructions.

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -25,12 +25,11 @@ rm -rf ~/.lando/scripts
 
 ## 2. WSL2 on Windows
 
-While you _can_ use Lando on your host Windows machine and have it talk to the Docker Desktop WSL2 backend it's probably _best_ to spin up another Linux distribution like Ubuntu, also install Lando there and do all your development there. This avoids most file sharing misery and as you might expect is almost as fast as running on Linux natively.
+While you _can_ use Lando on your host Windows machine and have it talk to the Docker Desktop WSL2 backend it's probably _best_ to spin up another Linux distribution like Ubuntu and install Lando there. This avoids most file sharing misery and as you might expect is almost as fast as running on Linux natively.
 
 In this model the user can usually use something like Windows Terminal to directly interface with the WSL2 machine or something like the [WSL2 Extension in VSCODE](https://code.visualstudio.com/docs/remote/wsl) to directly edit their files on the same machine.
 
-
-Here is a good [third-party guide](https://alexanderallen.medium.com/installing-lando-in-wsl-2-f965c47a8f03) on setting most of the above up.
+To install Lando on your Linux environment in WSL2, follow the appropriate [Linux installation instructions](https://docs.lando.dev/install/linux.html).
 
 ## 3. Excluding directories
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,6 +100,12 @@ certutil -addstore -f "ROOT" C:\Users\ME\.lando\certs\lndo.site.pem
 certutil -delstore "ROOT" serial-number-hex
 ```
 
+Note that if you want to trust the cert and are using Lando within a Linux environment on WSL2, you'll need to use the path to the cert used by that Linux environment. Ex:
+
+```bash
+certutil -addstore -f "ROOT" \\wsl.localhost\LINUX-DISTRIBUTION\home\LINUX-USER\.lando\certs\lndo.site.pem
+```
+
 ### Debian
 
 ```bash


### PR DESCRIPTION
Implement @pkiff's suggestions regarding confusing Windows WSL2 advice and adding CA cert to trusted store when using WSL2.