### PR TITLE
Fix password prompts not rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.21.0-beta.18 - [April 26, 2024](https://github.com/lando/core/releases/tag/v3.21.0-beta.18)
+
+* Fixed bug that prevented password prompts from rendering
+
 ## v3.21.0-beta.17 - [April 23, 2024](https://github.com/lando/core/releases/tag/v3.21.0-beta.17)
 
 * Fixed some stuff in nascent `LandoService4` for demoing puroses

--- a/renderers/lando.js
+++ b/renderers/lando.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {EOL} = require('os');
-const {DefaultRenderer} = require('listr2');
+const {DefaultRenderer, ListrEventType} = require('listr2');
 
 class LandoRenderer extends DefaultRenderer {
   constructor(tasks, options, $renderHook) {
@@ -54,7 +54,7 @@ class LandoRenderer extends DefaultRenderer {
         this.update();
       });
     }
-    this.events.on('SHOULD_REFRESH_RENDER', () => {
+    this.events.on(ListrEventType.SHOULD_REFRESH_RENDER, () => {
       this.update();
     });
   }


### PR DESCRIPTION
Resolves #160 

There was a typo that was fixed [here in v3.21.0-beta15](https://github.com/lando/core/commit/ff8b9e3a28fcd3c1e0b47c84788dcd086117d330#r141381104) that was actually a typo in the upstream that we want to keep. I tweaked it to reference the enum from the upstream library instead so there's no confusion in the future.