### PR TITLE
lando/docs#277: Correct paths of docs referencing lando.service.md.

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -96,4 +96,4 @@ For example, in `php` you will want to use something like the [`getenv()`](https
 
 ## Environment Configuration
 
-If you'd like to avoid broad strokes and only inject certain environment variables into particular services, we recommend you make use of [service overrides](./lando-service.md).
+If you'd like to avoid broad strokes and only inject certain environment variables into particular services, we recommend you make use of [service overrides](./services/lando.md).

--- a/docs/events.md
+++ b/docs/events.md
@@ -6,7 +6,7 @@ description: Lando events let you run arbitrary commands before or after certain
 # Events
 
 ::: tip When should I use events instead of a build step?
-Unlike [build steps](./lando-service.md#build-steps) `events` will run **every time** so it is advisable to use them for automating common steps like compiling `sass` before or after your app starts and not installing lower level dependencies like `node modules` or `php extensions`.
+Unlike [build steps](./services/lando.md#build-steps) `events` will run **every time** so it is advisable to use them for automating common steps like compiling `sass` before or after your app starts and not installing lower level dependencies like `node modules` or `php extensions`.
 :::
 
 Events allow you to automate commands or tasks you might often or always run either `before` or `after` something happens. Generally, you can hook into `pre` and `post` events for every part of the Lando and App runtime. At time of writing, those events were as follows:

--- a/docs/files.md
+++ b/docs/files.md
@@ -5,7 +5,7 @@ description: Lando shares your application codebase, user folder and lando confi
 
 # Shared Files
 
-While you can also share in additional files and directories via Docker volumes (see [service overrides](./lando-service.md)), we share a few useful host directories into each service by default.
+While you can also share in additional files and directories via Docker volumes (see [service overrides](./services/lando.md)), we share a few useful host directories into each service by default.
 
 | Host Location | Container Location |
 | -- | -- |

--- a/docs/lando-service.md
+++ b/docs/lando-service.md
@@ -406,7 +406,7 @@ You can _probably_ force the original container behavior and by extention forego
 
 ### Setting the app mount
 
-Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](services/lando.md#app-mount) the `app_mount` by setting it to `false` or `disabled`.
+Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](lando.md#app-mount) the `app_mount` by setting it to `false` or `disabled`.
 
 This will prevent Lando from mounting your codebase to `/app` so the Docker image can use its own code at `/app`.
 

--- a/docs/lando-service.md
+++ b/docs/lando-service.md
@@ -406,7 +406,7 @@ You can _probably_ force the original container behavior and by extention forego
 
 ### Setting the app mount
 
-Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](./services/lando.md#app-mount) the `app_mount` by setting it to `false` or `disabled`.
+Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](services/lando.md#app-mount) the `app_mount` by setting it to `false` or `disabled`.
 
 This will prevent Lando from mounting your codebase to `/app` so the Docker image can use its own code at `/app`.
 

--- a/docs/lando-service.md
+++ b/docs/lando-service.md
@@ -406,7 +406,7 @@ You can _probably_ force the original container behavior and by extention forego
 
 ### Setting the app mount
 
-Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](https://docs.lando.dev/core/v3/lando-service.html#app-mount) the `app_mount` by setting it to `false` or `disabled`.
+Many Docker images will put code in `/app`. This directly conflicts with Lando's default codebase mount point. If you are running into a problem because of this collision, we recommend you [disable](./services/lando.md#app-mount) the `app_mount` by setting it to `false` or `disabled`.
 
 This will prevent Lando from mounting your codebase to `/app` so the Docker image can use its own code at `/app`.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -7,7 +7,7 @@ description: If you've ever tried to run a site with a shload of files using Doc
 
 If you've ever tried to run a site with a shload of files using Docker Desktop then you've likely experienced some of the [very well documented](https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076/89) performance issues associated with doing so. Usually, these performance issues manifest themselves in slow page load times, or exceptionally long cli operations like installing a dependency or clearing an application's cache.
 
-Similarly, since Lando is built on top of these technologies, you likely have experienced them while running big sites on Lando as well; despite the fact that we already [optimize our app mounts](./lando-service.md).
+Similarly, since Lando is built on top of these technologies, you likely have experienced them while running big sites on Lando as well; despite the fact that we already [optimize our app mounts](./services/lando.md).
 
 There are, however, a few different things you can do to improve performance.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,7 +33,7 @@ You will then need to `lando rebuild` your service for the changes to take effec
 
 ### 2. Overridding a particular service
 
-If you [override](./lando-service.md) a particular service and specify the external IP then Lando will honor that choice and not force override with the `bindAddress`.
+If you [override](./services/lando.md) a particular service and specify the external IP then Lando will honor that choice and not force override with the `bindAddress`.
 
 ```yaml
 # This will find a random port on 0.0.0.0

--- a/docs/services.md
+++ b/docs/services.md
@@ -5,7 +5,7 @@ description: Lando services are a curated set of Docker containers like php, apa
 
 # Services
 
-Lando services are our distillation of Docker containers into their most important options combined with some *special sauce* to setup good [networking](./networking.md), [certificates](./security.md) and [SSH keys](./ssh.md) as well as options to run [build steps](./lando-service.md) and provide low level [overrides](./lando-service.md).
+Lando services are our distillation of Docker containers into their most important options combined with some *special sauce* to setup good [networking](./networking.md), [certificates](./security.md) and [SSH keys](./ssh.md) as well as options to run [build steps](services/lando.md#build-steps) and provide low level [overrides](services/lando.md#overrides).
 
 You can use the top-level `services` config in your [Landofile](./index.md) to define and configure a service.
 
@@ -34,7 +34,7 @@ However we **highly recommend** you **do not** omit it! :)
 
 #### type
 
-`type` is the kind of service. By default Lando 3 has one type: [`lando`](./lando-service.md)
+`type` is the kind of service. By default Lando 3 has one type: [`lando`](services/lando.md)
 
 However, you can install plugins to get more `types` such as `php:8.2` or `postgres:12`.
 
@@ -46,16 +46,16 @@ For these options you will want to consult the documentation for the specific se
 
 ## Lando Service
 
-As mentioned above Lando 3 core ships with a single general purpose service called [`lando`](./lando-service.md). This service is similar to and replaces the now **DEPRECATED** [compose service](https://docs.lando.dev/plugins/compose/).
+As mentioned above Lando 3 core ships with a single general purpose service called [`lando`](services/lando.md). This service is similar to and replaces the now **DEPRECATED** [compose service](https://docs.lando.dev/plugins/compose/).
 
 All other `api: 3` services are built on top of this service so it's worth examining its features as they are available in _all other_ downstream services. Some of its key features are:
 
-* [Application Mounting](./lando-service.md)
-* [Build Steps](./lando-service.md)
+* [Application Mounting](services/lando.md)
+* [Build Steps](services/lando.md)
 * [Healthcheck](./healthcheck.md)
-* [SSL and Certs](./lando-service.md)
+* [SSL and Certs](services/lando.md)
 * [URL Scanning](./scanner.md)
-* [Docker Compose Overrides](./lando-service.md)
+* [Docker Compose Overrides](services/lando.md)
 
 That said, it's almost always better to use a pre-built supported service.
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -20,7 +20,7 @@ This allows you to:
 * Never have to worry about which version of `php` or `grunt` you need for each project ever again
 
 ::: warning Make sure to install your dependencies!!!
-You will want to make sure you install the tools you need inside of the services your app is running. If you are not clear on how to do this, check out either [build steps](./lando-service.md#build-steps) or our [`ssh`](https://docs.lando.dev/cli/ssh.html) command.
+You will want to make sure you install the tools you need inside of the services your app is running. If you are not clear on how to do this, check out either [build steps](./services/lando.md#build-steps) or our [`ssh`](https://docs.lando.dev/cli/ssh.html) command.
 :::
 
 ## Usage
@@ -310,7 +310,7 @@ Note that if you set `dir` option in your tooling command `pwd` will **ONLY** ev
 
 If you are not sure about what tools live inside your container, you can use `lando ssh` to drop into a shell on a specific service to both investigate and install any needed dependencies.
 
-Note that while you can do the below, it's, generally, recommended to install any additional dependencies as part of a build process using either the specific dependency management options built into the service you are using or with Lando's more generic [build steps](./lando-service.md#build-steps).
+Note that while you can do the below, it's, generally, recommended to install any additional dependencies as part of a build process using either the specific dependency management options built into the service you are using or with Lando's more generic [build steps](./services/lando.md#build-steps).
 
 ::: warning Make sure to install your dependencies!!!
 Not installing dependencies as part of the build process will result in the loss of those dependencies if `lando rebuild` is executed or the service container is removed.


### PR DESCRIPTION
Fixes lando/docs#277.
