### PR TITLE
Run user hooks regardless of buildScript status.

### DIFF
--- a/builders/lando-v4.js
+++ b/builders/lando-v4.js
@@ -455,8 +455,10 @@ module.exports = {
         // run user build scripts if we have them
         if (this.buildScript && typeof this.buildScript === 'string') {
           this.addHookFile(this.buildScript, {stage: 'app', hook: 'user'});
-          await this.runHook(['app', 'user']);
         };
+
+        // Run user app build.
+        await this.runHook(['app', 'user']);
 
         // state
         this.info = {state: {APP: 'BUILT'}};


### PR DESCRIPTION
`this.buildScript` reflects what's in the Landofile, but if you use `addHookFile()` in a builder to add a user hook, it won't be reflected in `this.buildScript`. Lando should execute `await this.runHook(['app', 'user']);` regardless of `this.buildScript`.