### PR TITLE
Update proxy docs file provider directory

### DIFF
--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -245,7 +245,7 @@ proxyCommand:
   - "--entrypoints.https.address=:443"
   - "--entrypoints.http.address=:80"
   - "--providers.docker.exposedbydefault=false"
-  - "--providers.file.directory=/lando/proxy/config"
+  - "--providers.file.directory=/proxy_config"
   - "--providers.file.watch=true"
 # This is an object you can use to configure dynamic traefik 2 config
 # NOTE: that it must be in YAML format


### PR DESCRIPTION
The sample `proxyCommand` configuration of the `config.yml` file [in the docs](https://docs.lando.dev/core/v3/proxy.html#configuration) differs from the [actual default values](https://github.com/lando/core/blob/v3.21.2/plugins/proxy/index.js#L22) which leads to Lando services not being available if one wants to adjust other parameters from the Traeffic start command.