### PR TITLE
Support endeavouros

### DIFF
--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -17,7 +17,7 @@ case "$LANDO_LINUX_DISTRO" in
   alpine)
     export LANDO_LINUX_PACKAGE_MANAGER="apk"
     ;;
-  arch|archarm|manjaro)
+  arch|archarm|manjaro|endeavouros)
     export LANDO_LINUX_PACKAGE_MANAGER="pacman"
     ;;
   centos)

--- a/scripts/install-system-ca-linux.sh
+++ b/scripts/install-system-ca-linux.sh
@@ -59,7 +59,7 @@ case "$LANDO_LINUX_DISTRO" in
   alpine)
     export LANDO_LINUX_PACKAGE_MANAGER="apk"
     ;;
-  arch|archarm|manjaro)
+  arch|archarm|manjaro|endeavouros)
     export LANDO_LINUX_PACKAGE_MANAGER="pacman"
     ;;
   centos)


### PR DESCRIPTION
Currently running into this problem when starting lando:
```
Let's get this party started! Starting app vsm-service...
[+] Running Setup Tasks 4/4
 ✖ endeavouros not supported! Could not locate package manager!   FAILED
```

Since EndeavourOS is arch based, we can just add this to the check.