### PR TITLE
Improved CA setup support for less-popular Linux distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added fallback method for for installing CA on Linux distros that are based on other supported distros
+
 ## v3.22.0 - [October 10, 2024](https://github.com/lando/core/releases/tag/v3.22.0)
 
 ## New Features

--- a/scripts/install-system-ca-linux.sh
+++ b/scripts/install-system-ca-linux.sh
@@ -42,43 +42,66 @@ debug "CA: $CA"
 debug "CI: ${CI:-}"
 debug "DEBUG: $DEBUG"
 
-# Path to the os-release file
+# Paths to the os-release files
 OS_RELEASE_FILE="/etc/os-release"
+USR_OS_RELEASE_FILE="/usr/lib/os-release"
 
-# Check if the os-release file exists
-if [ ! -f "$OS_RELEASE_FILE" ]; then
-  echo "$OS_RELEASE_FILE not found." >&2
+if [ -f "$OS_RELEASE_FILE" ]; then
+  OS_RELEASE_FILE="$USR_OS_RELEASE_FILE"
+else
+  echo "Neither $OS_RELEASE_FILE nor $USR_OS_RELEASE_FILE found." >&2
   exit 1
 fi
 
 export LANDO_LINUX_DISTRO=$(grep -E '^ID=' "$OS_RELEASE_FILE" | cut -d '=' -f 2 | tr -d '"')
 export LANDO_LINUX_DISTRO_LIKE=$(grep -E '^ID_LIKE=' "$OS_RELEASE_FILE" | cut -d '=' -f 2 | tr -d '"')
+export LANDO_LINUX_NAME=$(grep -E '^NAME=' "$OS_RELEASE_FILE" | cut -d '=' -f 2 | tr -d '"')
+
+# Function to set package manager based on distro
+set_package_manager() {
+  case "$1" in
+    alpine)
+      export LANDO_LINUX_PACKAGE_MANAGER="apk"
+      ;;
+    arch|archarm|manjaro)
+      export LANDO_LINUX_PACKAGE_MANAGER="pacman"
+      ;;
+    centos)
+      export LANDO_LINUX_PACKAGE_MANAGER="yum"
+      ;;
+    debian|pop|ubuntu)
+      export LANDO_LINUX_PACKAGE_MANAGER="apt"
+      ;;
+    fedora)
+      export LANDO_LINUX_PACKAGE_MANAGER="dnf"
+      ;;
+    ol)
+      export LANDO_LINUX_PACKAGE_MANAGER="microdnf"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  return 0
+}
 
 # Find correct package manager based on DISTRO
-case "$LANDO_LINUX_DISTRO" in
-  alpine)
-    export LANDO_LINUX_PACKAGE_MANAGER="apk"
-    ;;
-  arch|archarm|manjaro)
-    export LANDO_LINUX_PACKAGE_MANAGER="pacman"
-    ;;
-  centos)
-    export LANDO_LINUX_PACKAGE_MANAGER="yum"
-    ;;
-  debian|pop|ubuntu)
-    export LANDO_LINUX_PACKAGE_MANAGER="apt"
-    ;;
-  fedora)
-    export LANDO_LINUX_PACKAGE_MANAGER="dnf"
-    ;;
-  ol)
-    export LANDO_LINUX_PACKAGE_MANAGER="microdnf"
-    ;;
-  *)
-    echo "$LANDO_LINUX_DISTRO not supported! Could not locate package manager!" >&2
-    exit 1
-    ;;
-esac
+if ! set_package_manager "$LANDO_LINUX_DISTRO"; then
+  # If DISTRO is not recognized, check ID_LIKE
+  IFS=' ' read -ra DISTRO_LIKE <<< "$LANDO_LINUX_DISTRO_LIKE"
+  for distro in "${DISTRO_LIKE[@]}"; do
+    if set_package_manager "$distro"; then
+      debug "$LANDO_LINUX_NAME ($LANDO_LINUX_DISTRO) is not directly supported. Falling back to $distro-like behavior."
+      break
+    fi
+  done
+fi
+
+# If still not set, exit with error
+if [ -z "$LANDO_LINUX_PACKAGE_MANAGER" ]; then
+  echo "$LANDO_LINUX_DISTRO not supported! Could not locate package manager!" >&2
+  exit 1
+fi
 
 # Use PACKAGE_MANAGER env var if available, argument if not
 if ! command -v "$LANDO_LINUX_PACKAGE_MANAGER" > /dev/null 2>&1; then
@@ -121,16 +144,19 @@ fi
 
 # abort if we cannot install the things we need
 if [ ! -x "$(command -v update-ca-certificates)" ] && [ ! -x "$(command -v update-ca-trust)" ]; then
-  abort "$LANDO_LINUX_PACKAGE_MANAGER not supported! Could not install ca-certs!"
+  echo "$LANDO_LINUX_PACKAGE_MANAGER not supported! Could not install ca-certs!" >&2
+  exit 1
 fi
 
 # move all cas to the correct place and update trust
 case $LANDO_LINUX_PACKAGE_MANAGER in
-  dnf|microdnf|yum)
+  dnf|microdnf|yum|pacman)
+    mkdir -p /etc/pki/ca-trust/source/anchors
     cp -r "$CA" /etc/pki/ca-trust/source/anchors/
     update-ca-trust
     ;;
   *)
+    mkdir -p /usr/local/share/ca-certificates
     cp -r "$CA" /usr/local/share/ca-certificates/
     update-ca-certificates
     ;;

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,15 +1,20 @@
 #!/bin/sh
 
-# Set lando debug
+# This script contains utility functions for Lando
+
+# Enable debug mode if DEBUG environment variable is set to "1"
 if [ "$DEBUG" = "1" ]; then
   LANDO_DEBUG="--debug"
 fi
 
+# Define terminal color escape sequences if output is to a terminal
 if [ -t 1 ]; then
   tty_escape() { printf "\033[%sm" "$1"; }
 else
   tty_escape() { :; }
 fi
+
+# Define color and style functions
 tty_mkbold() { tty_escape "1;$1"; }
 tty_mkdim() { tty_escape "2;$1"; }
 tty_blue="$(tty_escape 34)"
@@ -22,10 +27,18 @@ tty_reset="$(tty_escape 0)"
 tty_underline="$(tty_escape "4;39")"
 tty_yellow="$(tty_escape 33)"
 
+# Remove trailing newline from a string
 chomp() {
   printf "%s" "${1%$'\n'}"
 }
 
+# Join arguments into a single string, escaping spaces
+# This function takes any number of arguments and joins them into a single string,
+# escaping spaces in each argument. This is useful for creating command strings
+# that can be safely passed to other commands or functions.
+#
+# Usage: shell_join arg1 "arg 2" arg3
+# Output: arg1 arg\ 2 arg3
 shell_join() {
   local arg
   printf "%s" "${1:-}"
@@ -36,12 +49,17 @@ shell_join() {
   done
 }
 
-# redefine this one
+# Print an error message and exit
 abort() {
   printf "${tty_red}ERROR${tty_reset}: %s\n" "$(chomp "$1")" >&2
   exit 1
 }
 
+# Print multiple error messages and exit
+# This function reads lines from standard input and prints each line
+# as an error message. After all lines are printed, the script exits.
+#
+# Usage: echo -e "Error 1\nError 2" | abort_multi
 abort_multi() {
   while read -r line; do
     printf "${tty_red}ERROR${tty_reset}: %s\n" "$(chomp "$line")" >&2
@@ -49,12 +67,18 @@ abort_multi() {
   exit 1
 }
 
+# Print a debug message if debug mode is enabled
 debug() {
   if [ -n "${LANDO_DEBUG-}" ]; then
     printf "${tty_dim}debug${tty_reset} %s\n" "$(shell_join "$@")" >&2
   fi
 }
 
+# Print multiple debug messages if debug mode is enabled
+# This function reads lines from standard input and prints each line
+# as a debug message, prefixed with the first argument.
+#
+# Usage: echo -e "line1\nline2" | debug_multi "prefix"
 debug_multi() {
   if [ -n "${LANDO_DEBUG-}" ]; then
     while read -r line; do
@@ -63,10 +87,24 @@ debug_multi() {
   fi
 }
 
+# Print a log message
 log() {
   printf "%s\n" "$(shell_join "$@")"
 }
 
+# Retry a command with exponential backoff
+# This function attempts to run a command multiple times, with increasing
+# delays between attempts. It's useful for commands that may fail due to
+# temporary issues (e.g., network problems).
+#
+# Usage: retry command [arg1 [arg2 ...]]
+#
+# Environment variables:
+#   MAX_ATTEMPTS: Maximum number of attempts (default: 10)
+#   INITIAL_DELAY: Initial delay in seconds (default: 1)
+#   FACTOR: Multiplier for delay increase (default: 2)
+#
+# Example: retry curl http://example.com
 retry() {
   max_attempts=${MAX_ATTEMPTS-10}
   initial_delay=${INITIAL_DELAY-1}
@@ -93,10 +131,16 @@ retry() {
   done
 }
 
+# Print a warning message
 warn() {
   printf "${tty_yellow}warning${tty_reset}: %s\n" "$(chomp "$@")" >&2
 }
 
+# Print multiple warning messages
+# This function reads lines from standard input and prints each line
+# as a warning message.
+#
+# Usage: echo -e "Warning 1\nWarning 2" | warn_multi
 warn_multi() {
   while read -r line; do
     warn "${line}"


### PR DESCRIPTION
When determining the package manager, CA setup now checks ID_LIKE as a fallback to use the base distro when the current distro is unknown. For example, Linux Mint falls back to debian/apt and Endeavour OS falls back to arch/pacman.

Also fixed a bug where the wrong ca update command was run on arch-based systems.

Resolves lando/lando#3749
Resolves lando/core#225
Resolves lando/core#223