### PR TITLE
fix: correct assignment of task.title variable

### DIFF
--- a/lib/updates.js
+++ b/lib/updates.js
@@ -279,7 +279,7 @@ module.exports = class UpdateManager {
                 const rcFile = require('../utils/get-shell-profile')();
                 require('../utils/update-shell-profile')(rcFile, shellEnv);
                 this.debug('added %o to %o', shellEnv, rcFile);
-                task.title `${task.title}. Start a new terminal session to use the updated ${color.bold(`lando`)}`;
+                task.title = `${task.title}. Start a new terminal session to use the updated ${color.bold(`lando`)}`;
 
               // otherwis i guess do something else?
               // @TODO: throw a warning?


### PR DESCRIPTION
This PR fixes the update process of `@lando/cli` via the `lando update` command.