### PR TITLE
Easy ci execution

### DIFF
--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -81,6 +81,7 @@ module.exports = {
       const environment = {
         LANDO_SERVICE_NAME: name,
         LANDO_SERVICE_TYPE: type,
+        LANDO_SERVICE_API: 3,
       };
 
       // Handle labels

--- a/hooks/app-run-events.js
+++ b/hooks/app-run-events.js
@@ -4,28 +4,6 @@ const _ = require('lodash');
 
 module.exports = async (app, lando, cmds, data, event) => {
   const eventCommands = require('./../utils/parse-events-config')(cmds, app, data);
-  // add perm sweeping to all v3 services
-  if (!_.isEmpty(eventCommands)) {
-    const permsweepers = _(eventCommands)
-      .filter(command => command.api === 3)
-      .map(command => ({id: command.id, services: _.get(command, 'opts.services', [])}))
-      .uniqBy('id')
-      .value();
-    lando.log.debug('added preemptive perm sweeping to evented v3 services %j', permsweepers.map(s => s.id));
-    _.forEach(permsweepers, ({id, services}) => {
-      eventCommands.unshift({
-        id,
-        cmd: '/helpers/user-perms.sh --silent',
-        compose: app.compose,
-        project: app.project,
-        opts: {
-          mode: 'attach',
-          user: 'root',
-          services,
-        },
-      });
-    });
-  }
   const injectable = _.has(app, 'engine') ? app : lando;
   return injectable.engine.run(eventCommands).catch(err => {
     const command = _.tail(event.split('-')).join('-');

--- a/hooks/app-run-events.js
+++ b/hooks/app-run-events.js
@@ -4,6 +4,28 @@ const _ = require('lodash');
 
 module.exports = async (app, lando, cmds, data, event) => {
   const eventCommands = require('./../utils/parse-events-config')(cmds, app, data);
+  // add perm sweeping to all v3 services
+  if (!_.isEmpty(eventCommands)) {
+    const permsweepers = _(eventCommands)
+      .filter(command => command.api === 3)
+      .map(command => ({id: command.id, services: _.get(command, 'opts.services', [])}))
+      .uniqBy('id')
+      .value();
+    lando.log.debug('added preemptive perm sweeping to evented v3 services %j', permsweepers.map(s => s.id));
+    _.forEach(permsweepers, ({id, services}) => {
+      eventCommands.unshift({
+        id,
+        cmd: '/helpers/user-perms.sh --silent',
+        compose: app.compose,
+        project: app.project,
+        opts: {
+          mode: 'attach',
+          user: 'root',
+          services,
+        },
+      });
+    });
+  }
   const injectable = _.has(app, 'engine') ? app : lando;
   return injectable.engine.run(eventCommands).catch(err => {
     const command = _.tail(event.split('-')).join('-');

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -22,6 +22,19 @@ const composeFlags = {
   volumes: '-v',
 };
 
+const composeFlagOptionMapping = {
+  build: ['noCache', 'pull', 'q'],
+  down: ['removeOrphans', 'volumes'],
+  exec: ['background', 'detach', 'noTTY'],
+  kill: ['removeOrphans'],
+  logs: ['follow', 'timestamps'],
+  ps: ['q'],
+  pull: ['q'],
+  rm: ['force', 'volumes'],
+  up: ['background', 'detach', 'noRecreate', 'noDeps', 'pull', 'q', 'recreate', 'removeOrphans', 'timestamps'],
+  config: ['outputFilePath', 'q'],
+};
+
 // Default options nad things
 const defaultOptions = {
   build: {noCache: false, pull: true},
@@ -38,7 +51,14 @@ const defaultOptions = {
 /*
  * Helper to merge options with default
  */
-const mergeOpts = (run, opts = {}) => _.merge({}, defaultOptions[run], opts);
+const mergeOpts = (run, opts = {}) => _.merge(
+  {},
+  defaultOptions[run],
+  _.pickBy(
+    opts,
+    (value, index) => (!_.includes(_.keys(composeFlags), index)) || _.includes(composeFlagOptionMapping[run], index),
+  ),
+);
 
 /*
  * Parse docker-compose options

--- a/lib/router.js
+++ b/lib/router.js
@@ -85,6 +85,19 @@ exports.run = (data, compose, docker, started = true) => Promise.mapSeries(norma
         // if this is a prestart build step and its not the last one make sure we set started = true
         // this prevents us from having to stop and then restart the container during builds
         started = _.get(datum, 'opts.prestart', false) && !_.get(datum, 'opts.last', false);
+
+        const cmd = [
+          '/bin/sh',
+          '-c',
+          // eslint-disable-next-line max-len
+          'if [ "$LANDO_SERVICE_API" = "3" ]; then if [ -f /helpers/check-entrypoint-ran.sh ]; then /helpers/check-entrypoint-ran.sh; fi fi',
+        ];
+        return compose('run', _.merge(
+          {},
+          datum,
+          {opts: {cmd, id: datum.id, user: 'root', mode: 'attach'}},
+          ),
+        );
       });
     }
   })

--- a/scripts/check-entrypoint-ran.sh
+++ b/scripts/check-entrypoint-ran.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# retry settings
+attempt=0
+delay=1
+retry=16
+
+until [ "$attempt" -ge "$retry" ]
+do
+  test -f "/tmp/lando-entrypoint-ran" && break
+  attempt=$((attempt+1))
+  sleep "$delay"
+done

--- a/scripts/lando-entrypoint.sh
+++ b/scripts/lando-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ -f /tmp/lando-entrypoint-ran ]; then
+  rm /tmp/lando-entrypoint-ran
+fi
+
 # Get the lando logger
 . /helpers/log.sh
 
@@ -72,6 +76,8 @@ fi
 # Run the COMMAND
 # @TODO: We should def figure out whether we can get away with running everything through exec at some point
 lando_info "Lando handing off to: $@"
+
+touch /tmp/lando-entrypoint-ran
 
 # Try to DROP DOWN to another user if we can
 if [ ! -z ${LANDO_DROP_USER+x} ]; then

--- a/scripts/user-perm-helpers.sh
+++ b/scripts/user-perm-helpers.sh
@@ -84,6 +84,7 @@ perm_sweep() {
   chown -R $USER:$GROUP /usr/local/bin
   chown $USER:$GROUP /var/www
   chown $USER:$GROUP /app
+  chown $USER:$GROUP /tmp
   chmod 755 /var/www
 
   # Do other dirs first if we have them

--- a/tasks/ssh.js
+++ b/tasks/ssh.js
@@ -40,6 +40,8 @@ module.exports = (lando, app) => ({
         const api = _.get(_.find(app.info, {service}), 'api', 3);
         // set additional opt defaults if possible
         const opts = [undefined, api === 4 ? undefined : '/app'];
+        opts[2] = !app._config.command.deps ?? false;
+        opts[3] = app._config.command.autoRemove ?? true;
         // mix any v4 service info on top of app.config.services
         const services = _(_.get(app, 'config.services', {}))
           .map((service, id) => _.merge({}, {id}, service))

--- a/utils/build-tooling-runner.js
+++ b/utils/build-tooling-runner.js
@@ -20,7 +20,17 @@ const getContainerPath = (appRoot, appMount = undefined) => {
   return dir.join('/');
 };
 
-module.exports = (app, command, service, user, env = {}, dir = undefined, appMount = undefined) => ({
+module.exports = (
+  app,
+  command,
+  service,
+  user,
+  env = {},
+  dir = undefined,
+  appMount = undefined,
+  noDeps = false,
+  autoRemove = true,
+) => ({
   id: getContainer(app, service),
   compose: app.compose,
   project: app.project,
@@ -32,6 +42,8 @@ module.exports = (app, command, service, user, env = {}, dir = undefined, appMou
     user: (user === null) ? require('./get-user')(service, app.info) : user,
     services: _.compact([service]),
     hijack: false,
-    autoRemove: true,
+    autoRemove,
+    noDeps,
+    prestart: !autoRemove,
   }, _.identity),
 });

--- a/utils/build-tooling-task.js
+++ b/utils/build-tooling-task.js
@@ -24,7 +24,11 @@ module.exports = (config, injected) => {
     // Get an interable of our commandz
     .then(() => _.map(require('./parse-tooling-config')(cmd, service, options, answers, canExec)))
     // Build run objects
-    .map(({command, service}) => require('./build-tooling-runner')(app, command, service, user, env, dir, appMount))
+    .map(
+      ({command, service}) =>
+        require('./build-tooling-runner')(
+          app, command, service, user, env, dir, appMount, !answers.deps ?? false, answers.autoRemove ?? true,
+        ))
     // Try to run the task quickly first and then fallback to compose launch
     .each(runner => require('./build-docker-exec')(injected, stdio, runner).catch(execError => {
       return injected.engine.isRunning(runner.id).then(isRunning => {

--- a/utils/filter-v3-build-steps.js
+++ b/utils/filter-v3-build-steps.js
@@ -33,26 +33,8 @@ module.exports = (services, app, rootSteps = [], buildSteps= [], prestart = fals
       }
     });
   });
-  // Let's silent run user-perm stuff and add a "last" flag
+  // Let's add a "last" flag
   if (!_.isEmpty(build)) {
-    const permsweepers = _(build)
-      .map(command => ({id: command.id, services: _.get(command, 'opts.services', [])}))
-      .uniqBy('id')
-      .value();
-    _.forEach(permsweepers, ({id, services}) => {
-      build.unshift({
-        id,
-        cmd: '/helpers/user-perms.sh --silent',
-        compose: app.compose,
-        project: app.project,
-        opts: {
-          mode: 'attach',
-          prestart,
-          user: 'root',
-          services,
-        },
-      });
-    });
     // Denote the last step in the build if its happening before start
     const last = _.last(build);
     last.opts.last = prestart;


### PR DESCRIPTION
Add two cli options "--no-deps" and "--no-auto-remove" to run tooling commands or ssh/exec without starting any depending services and stop it afterwards.
This is really useful for us regarding CI environments. You can run "one-off" commands as "lando --no-deps --no-auto-remove composer php-cs-fixer" to lint the code without starting e.g. a depending database service and stopping the service afterwards, which saves some cycles on a subsequent command.

What do you think of it?

Thanks for any feedback,
Flo