### PR TITLE
Add `--tail` `--since` `--until` flags to `lando logs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
 * Added `--tail` option to `lando logs` command to allow users to specify the number of lines to show from the end of the logs for each service
+* Added `--since` and `--until` options to `lando logs` command to allow users to specify a range of logs to show
 
 ## v3.24.0-beta.12 - [January 24, 2025](https://github.com/lando/core/releases/tag/v3.24.0-beta.12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Added `--tail` option to `lando logs` command to allow users to specify the number of lines to show from the end of the logs for each service
+
 ## v3.24.0-beta.12 - [January 24, 2025](https://github.com/lando/core/releases/tag/v3.24.0-beta.12)
 
 * Merged in improvements from `@lando/core@v3.23.26`

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -18,8 +18,10 @@ const composeFlags = {
   recreate: '--force-recreate',
   removeOrphans: '--remove-orphans',
   rm: '--rm',
+  since: '--since',
   tail: '--tail',
   timestamps: '--timestamps',
+  until: '--until',
   volumes: '-v',
 };
 

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -44,7 +44,11 @@ const mergeOpts = (run, opts = {}) => _.merge({}, defaultOptions[run], opts);
  * Parse docker-compose options
  */
 const parseOptions = (opts = {}) => {
-  const flags = _.map(composeFlags, (value, key) => _.get(opts, key, false) ? value : '');
+  const flags = _.map(composeFlags, (value, key) => {
+    const optValue = _.get(opts, key, false);
+    if (optValue === false) return '';
+    return optValue === true ? value : `${value}=${optValue}`;
+  });
   const environment = _.flatMap(opts.environment, (value, key) => ['--env', `${key}=${value}`]);
   const user = (_.has(opts, 'user')) ? ['--user', opts.user] : [];
   const workdir = (_.has(opts, 'workdir')) ? ['--workdir', opts.workdir] : [];

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -18,6 +18,7 @@ const composeFlags = {
   recreate: '--force-recreate',
   removeOrphans: '--remove-orphans',
   rm: '--rm',
+  tail: '--tail',
   timestamps: '--timestamps',
   volumes: '-v',
 };

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -302,6 +302,7 @@ module.exports = class Engine {
    * @param {Array} data.compose An Array of paths to Docker compose files
    * @param {String} data.project A String of the project name (Usually this is the same as the app name)
    * @param {Object} [data.opts] Options on how to build the `compose` objects containers.
+   * @param {String} [data.opts.tail='all'] Number of lines to tail.
    * @param {Boolean} [data.opts.follow=false] Whether to follow the log. Works like `tail -f`.
    * @param {Boolean} [data.opts.timestamps=true] Show timestamps in log.
    * @return {Promise} A Promise.

--- a/tasks/logs.js
+++ b/tasks/logs.js
@@ -8,6 +8,7 @@ module.exports = lando => ({
   usage: '$0 logs [--follow] [--service <service>...] [--timestamps]',
   examples: [
     '$0 logs',
+    '$0 logs --tail 10',
     '$0 logs --follow --service appserver',
   ],
   options: {
@@ -22,6 +23,12 @@ module.exports = lando => ({
       alias: ['s'],
       array: true,
     },
+    tail: {
+      describe: 'Number of lines to show from the end of the logs for each service',
+      alias: ['n'],
+      default: 'all',
+      type: 'string',
+    },
     timestamps: {
       describe: 'Shows log timestamps',
       alias: ['t'],
@@ -32,7 +39,7 @@ module.exports = lando => ({
   run: options => {
     // Try to get our app
     const app = lando.getApp(options._app.root);
-    const opts = _.pick(options, ['follow', 'timestamps', 'service']);
+    const opts = _.pick(options, ['follow', 'tail', 'timestamps', 'service']);
     opts.services = opts.service;
     if (app) return app.init().then(() => lando.engine.logs(_.merge(app, {opts})));
   },

--- a/tasks/logs.js
+++ b/tasks/logs.js
@@ -23,6 +23,10 @@ module.exports = lando => ({
       alias: ['s'],
       array: true,
     },
+    since: {
+      describe: 'Show logs since timestamp (e.g. 2025-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)',
+      type: 'string',
+    },
     tail: {
       describe: 'Number of lines to show from the end of the logs for each service',
       alias: ['n'],
@@ -35,11 +39,15 @@ module.exports = lando => ({
       default: false,
       boolean: true,
     },
+    until: {
+      describe: 'Show logs before timestamp (e.g. 2025-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)',
+      type: 'string',
+    },
   },
   run: options => {
     // Try to get our app
     const app = lando.getApp(options._app.root);
-    const opts = _.pick(options, ['follow', 'tail', 'timestamps', 'service']);
+    const opts = _.pick(options, ['follow', 'tail', 'timestamps', 'service', 'since', 'until']);
     opts.services = opts.service;
     if (app) return app.init().then(() => lando.engine.logs(_.merge(app, {opts})));
   },


### PR DESCRIPTION
* Added `--tail` option to `lando logs` command to allow users to specify the number of lines to show from the end of the logs for each service
* Added `--since` and `--until` options to `lando logs` command to allow users to specify a range of logs to show

These are native `docker-compose` flags, so we're just passing them along.