### PR TITLE
Fix string errors in some recipes

### DIFF
--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -151,7 +151,8 @@ module.exports = {
       // Handle custom config files
       for (let [remote, local] of Object.entries(config)) {
         // if we dont have entries we can work with then just go to the next iteration
-        if (!_.has(remoteFiles, remote) && (typeof remote !== 'string' || typeof local !== 'string')) continue;
+        const isValidLocal = typeof local === 'string' || local?.constructor?.name === 'ImportString';
+        if (!_.has(remoteFiles, remote) && (typeof remote !== 'string' || !isValidLocal)) continue;
 
         // if this is special type then get it from remoteFile
         remote = _.has(remoteFiles, remote) ? remoteFiles[remote] : path.resolve('/', remote);

--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -151,7 +151,7 @@ module.exports = {
       // Handle custom config files
       for (let [remote, local] of Object.entries(config)) {
         // if we dont have entries we can work with then just go to the next iteration
-        if (!_.has(remoteFiles, remote) && typeof remote !== 'string') continue;
+        if (!_.has(remoteFiles, remote) && (typeof remote !== 'string' || typeof local !== 'string')) continue;
 
         // if this is special type then get it from remoteFile
         remote = _.has(remoteFiles, remote) ? remoteFiles[remote] : path.resolve('/', remote);


### PR DESCRIPTION
Fixes `TypeError [ERR_INVALID_ARG_TYPE]: The "paths[1]" argument must be of type string. Received an instance of Object`

Fixes lando/lagoon#90