### PR TITLE
Fix URL for proxy docs

### DIFF
--- a/messages/cannot-start-proxy-warning.js
+++ b/messages/cannot-start-proxy-warning.js
@@ -8,5 +8,5 @@ module.exports = message => ({
     'The proxy has been disabled for now so you can continue to work.',
     'Check out the docs below, resolve your issue and build this app',
   ],
-  url: 'https://docs.lando.dev/config/proxy.html',
+  url: 'https://docs.lando.dev/core/v3/proxy.html',
 });


### PR DESCRIPTION
Possibly an old URL that now 404s, replaced by actual docs URL