### PR TITLE
Add docs redirect for https://docs.lando.dev/config/proxy.html

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -60,6 +60,7 @@ https://api.lando.dev/*               https://docs.lando.dev/:splat          302
 /basics/ssh.html                     /cli/ssh.html                           301
 /basics/basics.html                  /getting-started/what-it-do.html        301
 /config/index.html                   /config/global.html                     301
+/config/proxy.html                   /landofile/proxy.html                   301
 /contrib/contributing.html           /contrib                                301
 /contrib/talking-points.html         /contrib/evangelist.html#talking-points 301
 /contrib/triage-getting-started.html /contrib/coder.html#triaging-issues     301


### PR DESCRIPTION
This URL is referenced multiple times in Lando codebase, easier to fix with a redirect in the docs than to update several repos. At present it is a 404: https://docs.lando.dev/config/proxy.html

Hopefully this does the trick?

<img width="732" height="113" alt="image" src="https://github.com/user-attachments/assets/bc1dcfc8-4e2a-4816-a809-e770e309092d" />
