### PR TITLE
Bump Traefik version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Upgraded to `traefik` 2.11 [#400](https://github.com/lando/core/pull/400)
+
 ## v3.25.6 - [October 1, 2025](https://github.com/lando/core/releases/tag/v3.25.6)
 
 * Updated plugins to handle image switch to [bitnamilegacy](https://github.com/bitnami/containers/issues/83267) namespace

--- a/builders/_proxy.js
+++ b/builders/_proxy.js
@@ -10,7 +10,7 @@ const getProxy = ({proxyCommand, proxyPassThru, proxyDomain, userConfRoot, versi
   return {
     services: {
       proxy: {
-        image: 'traefik:2.2.0',
+        image: 'traefik:2.11.31',
         command: proxyCommand.join(' '),
         environment: {
           LANDO_APP_PROJECT: '_lando_',

--- a/docs/lando-101/lando-start.md
+++ b/docs/lando-101/lando-start.md
@@ -53,7 +53,7 @@ gff ~/code/lando-ops/guides-example-code/introduction-to-lando/lando-init
 CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS                                                                     NAMES
 c92d36534d66        devwithlando/php:7.3-apache-2        "/lando-entrypoint.s…"   25 seconds ago      Up 23 seconds       127.0.0.1:32953->80/tcp, 127.0.0.1:32952->443/tcp                         lando101_appserver_1
 a5d7060a15be        bitnami/mysql:5.7.29-debian-10-r51   "/lando-entrypoint.s…"   25 seconds ago      Up 23 seconds       127.0.0.1:32951->3306/tcp                                                 lando101_database_1
-7f64e8add1fd        traefik:2.2.0                        "/lando-entrypoint.s…"   30 hours ago        Up 25 seconds       127.0.0.1:80->80/tcp, 127.0.0.1:443->443/tcp, 127.0.0.1:32950->8080/tcp   landoproxyhyperion5000gandalfedition_proxy_1
+7f64e8add1fd        traefik:2.11.31                      "/lando-entrypoint.s…"   30 hours ago        Up 25 seconds       127.0.0.1:80->80/tcp, 127.0.0.1:443->443/tcp, 127.0.0.1:32950->8080/tcp   landoproxyhyperion5000gandalfedition_proxy_1
 
 ```
 


### PR DESCRIPTION
Fix for #399 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the core proxy to use traefik 2.11.31 and refreshes docs and changelog accordingly.
> 
> - **Proxy/Infrastructure**
>   - Bump proxy image from `traefik:2.2.0` to `traefik:2.11.31` in `builders/_proxy.js`.
> - **Docs**
>   - Update `docs/lando-101/lando-start.md` example `docker ps` output to show `traefik:2.11.31`.
> - **Changelog**
>   - Add unreleased note: upgraded to `traefik` 2.11 with PR reference in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c815b8a8be53d459ba4aadd1b9d7f6a427d6cfb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->