### PR TITLE
fix: add --load to buildx to ensure images are available locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed `buildx` built images not being available locally by adding `--load` flag
+
 ## v3.26.2 - [December 17, 2025](https://github.com/lando/core/releases/tag/v3.26.2)
 
 * Updated to use new Lando Alliance Apple Developer certificates

--- a/components/docker-engine.js
+++ b/components/docker-engine.js
@@ -251,6 +251,7 @@ class DockerEngine extends Dockerode {
         'buildx',
         'build',
         `--file=${dockerfile}`,
+        '--load',
         '--progress=plain',
         `--tag=${tag}`,
         context,


### PR DESCRIPTION
## Summary
- Adds `--load` flag to buildx command to load built images into the local Docker daemon

## Problem
When building v4 services with buildx, the resulting image was sometimes not found:
```
(HTTP code 404) no such image - No such image: lando/<image>:latest
```

By default, `docker buildx build` only stores images in the buildx cache, not the local Docker daemon's image store. When Docker Compose later tries to start containers, it can't find the image. I could only replicate this in WSL using Docker Desktop on Windows.

## Solution
Add `--load` (`--output=type=docker`) to export the build result into the local Docker daemon, making images immediately available for use. I can't identify any tradeoff from adding this. It just guarantees that the loading that we want to happen actually happens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures images built with Buildx are available to the local Docker daemon.
> 
> - Adds `--load` to `buildx build` in `components/docker-engine.js` so `--tag`ged images are loaded locally
> - Updates `CHANGELOG.md` under `UNRELEASED` to document the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac2ad994f6df36ca4eaedef6a62a2cc0995dad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->