### PR TITLE
docs: add workaround for PHP plugin tool install order with corporate certs

### DIFF
--- a/docs/guides/lando-corporate-network-tips.md
+++ b/docs/guides/lando-corporate-network-tips.md
@@ -125,6 +125,25 @@ services:
       - update-ca-certificates
 ```
 
+::: warning PHP plugin tools install before user build steps
+As of `@lando/php` 1.10.0+, tools like Composer are installed during the build phase **before** your `build_as_root` commands run. This means the cert won't be in place yet when tools try to download, causing SSL errors.
+
+To work around this, disable automatic tool installation and install them manually after your cert is in place:
+
+```yaml
+services:
+  appserver:
+    composer_version: false # Prevent automatic composer install
+    build_as_root:
+      - cp /app/yourcert.crt /usr/local/share/ca-certificates/
+      - chmod 644 /usr/local/share/ca-certificates/yourcert.crt
+      - update-ca-certificates
+      - /etc/lando/service/helpers/install-composer.sh 2 # Install composer after cert
+```
+
+The same approach applies to other PHP tools — disable their automatic installation via config, install your cert first, then install the tools manually using the helper scripts in `/etc/lando/service/helpers/`.
+:::
+
 #### Adding Certs for PHP cURL Requests
 If you make external requests with the PHP process in your app, you will also need to include the cert in your appserver's `php.ini` file:
 

--- a/docs/guides/lando-corporate-network-tips.md
+++ b/docs/guides/lando-corporate-network-tips.md
@@ -138,7 +138,7 @@ services:
       - cp /app/yourcert.crt /usr/local/share/ca-certificates/
       - chmod 644 /usr/local/share/ca-certificates/yourcert.crt
       - update-ca-certificates
-      - /etc/lando/service/helpers/install-composer.sh 2 # Install composer after cert
+      - /etc/lando/service/helpers/install-composer.sh # Install composer after cert
 ```
 
 The same approach applies to other PHP tools — disable their automatic installation via config, install your cert first, then install the tools manually using the helper scripts in `/etc/lando/service/helpers/`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,7 +30,9 @@
       "overrides",
       "fragment-check",
       "sqlshack",
-      "/v/"
+      "/v/",
+      "dockerfile-release-notes",
+      "jeffgeerling.com"
     ]
     skipPatterns = [
       ".gif",


### PR DESCRIPTION
As of `@lando/php` 1.10.0+, tools like Composer are installed during the build phase **before** user-defined `build_as_root` commands run. This breaks corporate proxy workflows where certs need to be installed before any downloads happen.

Adds a warning box to the corporate network tips guide documenting the workaround: disable automatic tool installation and manually install tools after the cert is in place.

Closes lando/php#236

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a minor Netlify deploy-preview link-check configuration tweak; no runtime/product code is modified.
> 
> **Overview**
> Adds a **warning callout** to `lando-corporate-network-tips.md` explaining that `@lando/php` 1.10.0+ installs tools (e.g., Composer) *before* user `build_as_root` steps, and documents a workaround to disable auto tool installs (e.g., `composer_version: false`) and run helper installers after corporate CA certs are added.
> 
> Updates `netlify.toml` link-check `todoPatterns` to include additional patterns and fixes the `/v/` entry formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acd38603d9a68140c9396f2cce97522950f04004. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->