### PR TITLE
fix: handle empty YAML config files gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed crash when `config.yml` is empty instead of containing `{}` [#439](https://github.com/lando/core/issues/439)
+
 ## v3.26.2 - [December 17, 2025](https://github.com/lando/core/releases/tag/v3.26.2)
 
 * Updated to use new Lando Alliance Apple Developer certificates

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -558,7 +558,7 @@ module.exports = class Cli {
     const Yaml = require(`../lib/yaml`);
     const yaml = new Yaml();
     const configFile = path.join(this.defaultConfig().userConfRoot, 'config.yml');
-    const config = (fs.existsSync(configFile)) ? yaml.load(configFile) : {};
+    const config = (fs.existsSync(configFile)) ? yaml.load(configFile) || {} : {};
     const file = yaml.dump(configFile, _.assign({}, config, data));
     return yaml.load(file);
   }

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -465,7 +465,7 @@ module.exports = class Lando {
     }
 
     // Load the config and augment so we can get an App
-    const config = lmerge({}, ..._.map(landoFiles, file => yaml.load(file)));
+    const config = lmerge({}, ..._.map(landoFiles, file => yaml.load(file) || {}));
     this.log.info('loading app %s from config files', config.name, landoFiles);
     // Return us some app!
     const App = require('./app');

--- a/utils/load-config-files.js
+++ b/utils/load-config-files.js
@@ -52,7 +52,7 @@ module.exports = files => _(files)
   .filter(source => fs.existsSync(source) || fs.existsSync(source.file))
   // If the file is just a string lets map it to an object
   .map(source => {
-    return _.isString(source) ? {file: source, data: yaml.load(fs.readFileSync(source))} : source;
+    return _.isString(source) ? {file: source, data: yaml.load(fs.readFileSync(source)) || {}} : source;
   })
   // Add on the root directory for mapping purposes
   .map(source => _.merge({}, source, {root: path.dirname(source.file)}))


### PR DESCRIPTION
## Summary

When `~/.lando/config.yml` is completely empty (no `{}`), `yaml.load()` returns `undefined` instead of an object. This causes a `TypeError: Cannot read properties of undefined (reading 'pluginDirs')` crash.

## Fix

Add `|| {}` fallback after every `yaml.load()` call that reads config files:

- `utils/load-config-files.js` — main config source loading
- `lib/cli.js` — CLI config reading
- `lib/lando.js` — landofile loading

## Testing

1. Empty your config: `echo '' > ~/.lando/config.yml`
2. Run any `lando` command
3. Before: TypeError crash. After: works normally.

Fixes #439
Fixes https://github.com/lando/lando/issues/3379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change that only affects config-loading edge cases; main risk is silently accepting unintended empty/invalid config content.
> 
> **Overview**
> Prevents crashes when config YAML files are present but empty by treating `yaml.load(...)` returning `undefined` as `{}`.
> 
> This adds `|| {}` fallbacks when loading user `~/.lando/config.yml`, app Landofiles, and config sources in `load-config-files`, and records the fix in `CHANGELOG.md` (fixes #439).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c2666ca8e524d1e6c90f46415113a197b3b41ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->