### PR TITLE
Windows postinstall script issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ config.*.timestamp-*-*.*
 yarn.lock
 
 
+# Claude
+CLAUDE.md
+
 # Syncthing
 .stfolder/
 .stversions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Lando is a local development orchestration tool built around Docker, recipes, an
 
 ## Architecture
 - `bin/lando` — CLI entrypoint/runtime selector.
-- `lib/lando.js` — package `main`; owns bootstrap sequencing.
+- `lib/lando.js` — package main export; owns bootstrap sequencing.
 - `index.js` — **not** the library entrypoint; it's the core plugin bootstrap that registers default config and lifecycle hooks.
 - Most behavior is wired through events and hook modules, not direct imports. Start with `lib/lando.js`, `app.js`, and `index.js`, then follow `hooks/`.
 - Bootstrap levels: `config → tasks → engine → app`. Tooling commands may only reach `engine` if compose cache exists, so not every CLI path initializes a full app.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@lando/core",
       "version": "3.26.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@lando/argv": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "all": true
   },
   "scripts": {
-    "postinstall": "command -v claude >/dev/null 2>&1 && ln -sf AGENTS.md CLAUDE.md || true",
+    "postinstall": "node -e \"try { require('child_process').execSync('claude --version', {stdio: 'ignore'}); require('fs').symlinkSync('AGENTS.md', 'CLAUDE.md', 'file'); } catch {}\"",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "docs:build": "VPL_MVB_VERSION=$(git describe --tags --always --abbrev=1 --match=\"v[0-9].*\") vitepress build docs && npm run docs:rename-sitemap",
     "docs:dev": "VPL_BASE_URL=http://localhost:5173 VPL_MVB_VERSION=$(git describe --tags --always --abbrev=1 --match=\"v[0-9].*\") vitepress dev docs",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "all": true
   },
   "scripts": {
+    "postinstall": "command -v claude >/dev/null 2>&1 && ln -sf AGENTS.md CLAUDE.md || true",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "docs:build": "VPL_MVB_VERSION=$(git describe --tags --always --abbrev=1 --match=\"v[0-9].*\") vitepress build docs && npm run docs:rename-sitemap",
     "docs:dev": "VPL_BASE_URL=http://localhost:5173 VPL_MVB_VERSION=$(git describe --tags --always --abbrev=1 --match=\"v[0-9].*\") vitepress dev docs",


### PR DESCRIPTION
Make the `postinstall` script cross-platform to prevent `npm install` failures on Windows.

The original `postinstall` script used POSIX-only commands (`command -v`, `ln -sf`, `true`) which caused `npm install` to fail on Windows due to `cmd.exe` not recognizing them. This fix replaces it with a Node.js script that achieves the same symlinking functionality in a cross-platform manner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `postinstall`, so any mistake can break installs or create unexpected filesystem artifacts across platforms, though the change is small and guarded with a try/catch.
> 
> **Overview**
> Fixes Windows `npm install` failures by replacing the POSIX-only `postinstall` script with a cross-platform Node one-liner that (when `claude` is available) creates a `CLAUDE.md` symlink to `AGENTS.md` and otherwise no-ops.
> 
> Adds `CLAUDE.md` to `.gitignore`, and updates `package-lock.json` metadata (`hasInstallScript`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8834b3038f998b0137571b4cd2a17289da30d97b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->