### PR TITLE
fix: respect v4 appserver as default ssh service in mixed-api apps

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -351,11 +351,15 @@ module.exports = class App {
 
       // reset the default service to the primary v4 service if we only have v4 services
       if (this._serviceApi === 4) this._defaultService = this.v4.primaryService.name;
-      // reset the default service to the first v3 service if there is no appserver
-      else if (this.serviceGroups['3'].length > 0 && !_.find(this.serviceGroups['3'], {service: 'appserver'})) {
+      // reset the default service to the first v3 service if there is no appserver in v3 or v4
+      else if (this.serviceGroups['3'].length > 0
+        && !_.find(this.serviceGroups['3'], {service: 'appserver'})
+        && !_.find(this.serviceGroups['4'], {service: 'appserver'})) {
         this._defaultService = this.serviceGroups['3'][0].service;
-      // reset the default service to the first compose service if there is no appserver
-      } else if (this.serviceGroups.compose.length > 0 && !_.find(this.serviceGroups.compose, {service: 'appserver'})) {
+      // reset the default service to the first compose service if there is no appserver in compose or v4
+      } else if (this.serviceGroups.compose.length > 0
+        && !_.find(this.serviceGroups.compose, {service: 'appserver'})
+        && !_.find(this.serviceGroups['4'], {service: 'appserver'})) {
         this._defaultService = this.serviceGroups.compose[0].service;
       }
 


### PR DESCRIPTION
When an app has both v3 and v4 services, the default service for `lando ssh` would incorrectly fall back to the first v3 service even if a v4 `appserver` existed. Now the fallback checks all API groups before overriding the default.

The logic of defaulting to a v3 service if there is no appserver is a little weird...open to suggestion there.