### PR TITLE
refactor(docs): slim contributors config, rely on theme defaults

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -86,18 +86,7 @@ export default defineConfig({
         patterns: ['help/**/*.md', 'troubleshooting/**/*.md'],
       },
     },
-    contributors: {
-      include: [
-        // Mike, Alec, and Aaron come from the landov3 defaults already
-        // (see @lando/vitepress-theme-default-plus/config/landov3.js).
-        // Only override the bits we want to change locally.
-        {
-          email: 'mike@lando.dev',
-          desc: 'SLAVE4U',
-          mergeOnly: true,
-        },
-      ],
-    },
+
     sidebar: {
       '/cli': cliBar(),
       '/config': configBar(),

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -87,38 +87,13 @@ export default defineConfig({
       },
     },
     contributors: {
-      merge: 'name',
-      debotify: true,
       include: [
+        // Mike, Alec, and Aaron come from the landov3 defaults already
+        // (see @lando/vitepress-theme-default-plus/config/landov3.js).
+        // Only override the bits we want to change locally.
         {
-          name: 'Mike Pirog',
           email: 'mike@lando.dev',
-          title: 'Co-founder',
-          org: 'lando.dev',
-          orgLink: 'https://lando.dev',
           desc: 'SLAVE4U',
-          links: [
-            {icon: 'github', link: 'https://github.com/pirog'},
-            {icon: 'x', link: 'https://x.com/pirogcommamike'},
-          ],
-          sponsor: 'https://lando.dev/sponsor',
-          maintainer: true,
-          mergeOnly: true,
-        },
-        {
-          avatar: 'https://avatars.githubusercontent.com/u/1153738',
-          name: 'Alec Reynolds',
-          email: 'alec+git@thinktandem.io',
-          title: 'Co-founder',
-          org: 'lando.dev',
-          orgLink: 'https://lando.dev',
-          desc: 'A chill dude',
-          links: [
-            {icon: 'github', link: 'https://github.com/reynoldsalec'},
-            {icon: 'x', link: 'https://x.com/reynoldsalec'},
-          ],
-          sponsor: 'https://lando.dev/sponsor',
-          maintainer: true,
           mergeOnly: true,
         },
       ],


### PR DESCRIPTION
Slims the `contributors` block in `docs/.vitepress/config.mjs` from ~30 lines to 5 by deferring to the updated `@lando/vitepress-theme-default-plus` defaults.

**Before:** locally copied Mike, Alec, and Aaron entries, plus a `{}` placeholder working around a lodash index-merge gotcha.

**After:** one single-field override to attach `desc: 'SLAVE4U'` to Mike. Maintainer entries (including Aaron, with `x` icons) come from theme defaults.

```js
contributors: {
  include: [
    {email: 'mike@lando.dev', desc: 'SLAVE4U', mergeOnly: true},
  ],
},
```

The `/team` page renders identically to before, plus Aaron Feledy now shows as a maintainer.

**Requires:** `@lando/vitepress-theme-default-plus` ≥ v1.2.0 (lando/vitepress-theme-default-plus#100).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-site configuration change; main impact is how the contributors/team data is sourced, which could alter `/team` rendering if theme defaults differ.
> 
> **Overview**
> Removes the locally defined `themeConfig.contributors` block from `docs/.vitepress/config.mjs`, deferring contributor/maintainer metadata to `@lando/vitepress-theme-default-plus` defaults.
> 
> This reduces duplication in docs config and shifts ownership of team entries (names, links, maintainer flags) to the theme configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ec822220fd1446eaf1ae6ecd77f1f3a342ae3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->