### PR TITLE
Fix sudo bell with stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed interactive sudo password handling to avoid combining `--bell` with `--stdin` [#386](https://github.com/lando/core/issues/386)
+
 ## v3.26.7 - [July 3, 2026](https://github.com/lando/core/releases/tag/v3.26.7)
 
 * Updated to use new Lando Alliance [Azure Artificate Signing](https://learn.microsoft.com/en-us/azure/artifact-signing/) certs

--- a/docs/contrib/coder.md
+++ b/docs/contrib/coder.md
@@ -4,7 +4,7 @@ description: Learn about how to get started contributing code to Lando.
 
 # Coding
 
-This section is designed for people who want to contribute `code things` to Lando. Specifically, that means [opening a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) against one of the many [Lando respositories](https://github.com/orgs/lando/repositories).
+This section is designed for people who want to contribute `code things` to Lando. Specifically, that means [opening a pull request](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/creating-a-pull-request) against one of the many [Lando respositories](https://github.com/orgs/lando/repositories).
 
 [[toc]]
 
@@ -20,11 +20,11 @@ If you are having issues with any of the above or need some guidance from one of
 
 ## Making your first pull request
 
-1. [Create a fork of the repo you are working on](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo).
+1. [Create a fork of the repo you are working on](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/fork-a-repo).
 2. [Follow the GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow).
 3. Make sure you complete any requested/applicable tasks in the PR template.
 4. Make sure all status checks and tests pass.
-5. Ping the `#contributors` channel in Slack for any needed [PR review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews) or any other help you may need advancing your PR.
+5. Ping the `#contributors` channel in Slack for any needed [PR review](https://docs.github.com/en/pull-requests/reference/pull-request-reviews) or any other help you may need advancing your PR.
 6. When all checks, tests and reviews are in the green ping a `maintainer` and/or apply the <Badge type="flag">flag</Badge> label.
 
 **If you have any trouble, need clarification, guidance, help, etc jump into the `#contributors` channel in Slack and another contributor will gladly help you out!**

--- a/docs/contrib/sponsoring.md
+++ b/docs/contrib/sponsoring.md
@@ -20,11 +20,11 @@ GitHub Sponsors, Patreon, and Open Collective: all three of these official Lando
 
 [Sponsor With GitHub Here](https://github.com/sponsors/lando)
 
-### [With Patreon](https://www.patreon.com/devwithlando)
+### [With Patreon](https://www.patreon.com/cw/devwithlando)
 
-The gold standard of sponsoring creatives, [Patreon](https://www.patreon.com/devwithlando) does charge a transactional fee; hence why you'll see sponsorship rates are a little higher there. Rest assured that Lando gets the same amount, but all things being equal, you might want to use GitHub Sponsors instead.
+The gold standard of sponsoring creatives, [Patreon](https://www.patreon.com/cw/devwithlando) does charge a transactional fee; hence why you'll see sponsorship rates are a little higher there. Rest assured that Lando gets the same amount, but all things being equal, you might want to use GitHub Sponsors instead.
 
-[Sponsor with Patreon Here](https://www.patreon.com/devwithlando)
+[Sponsor with Patreon Here](https://www.patreon.com/cw/devwithlando)
 
 ### [With Open Collective](https://opencollective.com/lando)
 

--- a/docs/landofile/proxy.md
+++ b/docs/landofile/proxy.md
@@ -273,7 +273,7 @@ Note that we generate a [Certificate Authority](../config/security.md) based on 
 
 If you are working offline and/or have added custom domains and want to get them to work, you will need to edit your `hosts` file. Generally, this file is located at `/etc/hosts` on Linux and macOS and `C:\Windows\System32\Drivers\etc\host` on Windows. You will need administrative privileges to edit this file.
 
-Here is a [good read](https://www.hostinger.com/tutorials/how-to-edit-hosts-file) if you are not very familiar with the `hosts` file, how to edit it and how it works.
+Here is a [good read](https://www.hostinger.com/tutorials/how-to-edit-hosts-file/) if you are not very familiar with the `hosts` file, how to edit it and how it works.
 
 An example is shown below:
 

--- a/docs/services/l337.md
+++ b/docs/services/l337.md
@@ -211,7 +211,7 @@ services:
       imagefile: nginx:1.21
 ```
 
-Note that if you do `buildkit: false` some image build features, specifically those in [Dockerfile 1.1.0+](https://github.com/moby/buildkit/releases/#110) and the [ssh](#ssh) features of this service, may not be available. You can also use `buildx` as an alias for `buildkit`. If you use both it will evaluate to `true` if either is `true`. Really just don't use both ;)!
+Note that if you do `buildkit: false` some image build features, specifically those in [Dockerfile 1.1.0+](https://github.com/moby/buildkit/releases/tag/dockerfile/1.1.0) and the [ssh](#ssh) features of this service, may not be available. You can also use `buildx` as an alias for `buildkit`. If you use both it will evaluate to `true` if either is `true`. Really just don't use both ;)!
 
 You probably should just ignore this setting unless you have a well understood reason to do otherwise.
 

--- a/test/run-elevated.spec.js
+++ b/test/run-elevated.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const child = require('child_process');
+const chai = require('chai');
+const sinon = require('sinon');
+chai.should();
+
+describe('run-elevated', () => {
+  let runElevated;
+  let spawn;
+
+  const getSudoArgv = options => {
+    runElevated(['whoami'], {method: 'sudo', ...options});
+    return spawn.firstCall.args[1];
+  };
+
+  before(() => {
+    spawn = sinon.stub(child, 'spawn').returns({});
+    delete require.cache[require.resolve('../utils/run-elevated')];
+    runElevated = require('../utils/run-elevated');
+  });
+
+  beforeEach(() => spawn.resetHistory());
+
+  after(() => {
+    spawn.restore();
+    delete require.cache[require.resolve('../utils/run-elevated')];
+  });
+
+  it('should use stdin without bell for an interactive password', () => {
+    getSudoArgv({isInteractive: true, password: 'secret'}).should.deep.equal([
+      '--stdin',
+      '--',
+      'whoami',
+    ]);
+  });
+
+  it('should use bell without stdin when interactive without a password', () => {
+    getSudoArgv({isInteractive: true}).should.deep.equal([
+      '--bell',
+      '--',
+      'whoami',
+    ]);
+  });
+
+  it('should use non-interactive mode when not interactive', () => {
+    getSudoArgv({isInteractive: false}).should.deep.equal([
+      '--non-interactive',
+      '--bell',
+      '--',
+      'whoami',
+    ]);
+  });
+
+  it('should omit bell when notifications are disabled', () => {
+    getSudoArgv({isInteractive: true, notify: false}).should.deep.equal([
+      '--',
+      'whoami',
+    ]);
+  });
+});

--- a/utils/run-elevated.js
+++ b/utils/run-elevated.js
@@ -47,13 +47,14 @@ module.exports = (command, options, stdout = '', stderr = '') => {
 
   // sudo
   if (options.method === 'sudo') {
+    const useStdin = options.isInteractive && options.password;
     command.unshift('--');
     // if we want to notify the user
-    if (options.notify) command.unshift('--bell');
+    if (options.notify && !useStdin) command.unshift('--bell');
     // if this is non-interactive then pass that along to sudo
     if (!options.isInteractive) command.unshift('--non-interactive');
     // if interactive and have a password then add -S so we can write the password to stdin
-    if (options.isInteractive && options.password) command.unshift('--stdin');
+    if (useStdin) command.unshift('--stdin');
 
   // run-elevated
   } else if (options.method === 'run-elevated') {


### PR DESCRIPTION
## Summary
- avoid passing sudo `--bell` when an interactive password requires `--stdin`
- cover interactive, noninteractive, and notification-disabled sudo argv

## Testing
- `npx mocha --timeout 5000 test/run-elevated.spec.js`
- `npx eslint utils/run-elevated.js test/run-elevated.spec.js`

Fixes #386
Fixes lando/lando#3818