### PR TITLE
fix: keep plugin list sorted alphabetically

### DIFF
--- a/docs/.vitepress/theme/VPLPluginItems.vue
+++ b/docs/.vitepress/theme/VPLPluginItems.vue
@@ -66,10 +66,11 @@ const props = defineProps({
 const amount = ref(props.pager);
 const key = ref(0);
 
+const sort = items => [...items].sort((a, b) => a.title.localeCompare(b.title));
+
 // normalize data and sort
-let pages = props.items
-  .map(item => Object.assign(item, {show: true, timestamp: item.date ? item.date : item.timestamp}))
-  .sort((a, b) => a.title > b.title ? 1 : -1);
+let pages = sort(props.items
+  .map(item => Object.assign(item, {show: true, timestamp: item.date ? item.date : item.timestamp})));
 
 const adder = () => amount.value += props.pager;
 
@@ -96,8 +97,8 @@ const pagination = () => pages.slice(0, amount.value);
 
 const filter = () => {
   const tagList = Object.entries(props.tags).filter(pair => pair[1].selected === true).map(pair => pair[0]);
-  if (tagList.length === 0) return props.items;
-  return props.items.filter(item => Array.isArray(item.tags) && tagList.every(tag => item.tags.includes(tag)));
+  if (tagList.length === 0) return sort(props.items);
+  return sort(props.items.filter(item => Array.isArray(item.tags) && tagList.every(tag => item.tags.includes(tag))));
 };
 
 // recompute filter when tags change


### PR DESCRIPTION
## What does this do?

Keeps the plugin directory alphabetically sorted after mounting and whenever tag filters change.

Previously, the component sorted its initial local array alphabetically, then replaced it with the content loader order during onMounted. Since the loader orders entries by their Git-derived timestamps, recently updated plugin metadata could jump to the front of the directory.

## Testing

- npm run docs:build
- git diff --check