### PR TITLE
fix: preserve configured orchestrator binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed valid custom `orchestratorBin` paths being overwritten by the Docker Compose fallback [lando/lando#3847](https://github.com/lando/lando/issues/3847)
 * Fixed interactive sudo password handling to avoid combining `--bell` with `--stdin` [#386](https://github.com/lando/core/issues/386)
 
 ## v3.26.7 - [July 3, 2026](https://github.com/lando/core/releases/tag/v3.26.7)

--- a/examples/orchestrator/README.md
+++ b/examples/orchestrator/README.md
@@ -35,14 +35,14 @@ LANDO_ORCHESTRATOR_VERSION="2.19.1" lando start -vvv 2>&1 | grep ".lando/bin/doc
 LANDO_ORCHESTRATOR_VERSION="UHNO" lando start -vvv 2>&1 | grep -E "/usr/local/bin/docker-compose|.lando/bin/docker-compose"
 
 # Should use the orchestratorBin if set
-LANDO_ORCHESTRATOR_BIN="/usr/local/bin/docker-compose" lando config --path orchestratorBin | grep "$LANDO_ORCHESTRATOR_BIN"
-LANDO_ORCHESTRATOR_BIN="/usr/local/bin/docker-compose" lando start -vvv 2>&1 | grep "$LANDO_ORCHESTRATOR_BIN"
+LANDO_ORCHESTRATOR_BIN="$HOME/.lando/bin/docker-compose-v2.19.1" lando config --path orchestratorBin --format json | tr -d '"' | grep -Fx "$HOME/.lando/bin/docker-compose-v2.19.1"
+LANDO_ORCHESTRATOR_BIN="$HOME/.lando/bin/docker-compose-v2.19.1" lando start -vvv 2>&1 | grep -F "$HOME/.lando/bin/docker-compose-v2.19.1"
 
 # Should set orchestratorBin with composeBin if orchestratorBin is not set
-LANDO_COMPOSE_BIN="/usr/local/bin/docker-compose" lando config --path orchestratorBin | grep "$LANDO_COMPOSE_BIN"
+LANDO_COMPOSE_BIN="$HOME/.lando/bin/docker-compose-v2.19.1" lando config --path orchestratorBin --format json | tr -d '"' | grep -Fx "$HOME/.lando/bin/docker-compose-v2.19.1"
 
 # Should prefer orchestratorBin to composeBin
-LANDO_COMPOSE_BIN="/usr/local/bin/bogus" LANDO_ORCHESTRATOR_BIN="/usr/local/bin/docker-compose" lando config --path orchestratorBin | grep "$LANDO_ORCHESTRATOR_BIN"
+LANDO_COMPOSE_BIN="/usr/local/bin/bogus" LANDO_ORCHESTRATOR_BIN="$HOME/.lando/bin/docker-compose-v2.19.1" lando config --path orchestratorBin --format json | tr -d '"' | grep -Fx "$HOME/.lando/bin/docker-compose-v2.19.1"
 ```
 
 ## Destroy tests

--- a/utils/build-config.js
+++ b/utils/build-config.js
@@ -84,7 +84,7 @@ module.exports = options => {
   }
 
   // if orchestrator is not a valid version then remove it and try to use a system provided orchestartor
-  if (require('semver/functions/valid')(config.orchestratorVersion) === null) {
+  if (!config.orchestratorBin && require('semver/functions/valid')(config.orchestratorVersion) === null) {
     config.orchestratorBin = require('./get-compose-x')(config);
     delete config.orchestratorVersion;
   }
@@ -108,4 +108,3 @@ module.exports = options => {
   // Return the config
   return config;
 };
-


### PR DESCRIPTION
## What does this do?

Preserves a valid absolute `orchestratorBin` instead of overwriting it with the system/default Docker Compose path.

It also repairs the existing Leia assertions for `orchestratorBin` and deprecated `composeBin` configuration. Those assertions expanded temporary environment variables before assignment, leaving `grep` to search for an empty string and pass regardless of the resolved binary.

## Verification

The repaired Leia test was pushed independently first. The orchestrator job failed on all three corrected assertions while its other five tests passed:

- custom `orchestratorBin` is used
- deprecated `composeBin` populates `orchestratorBin`
- `orchestratorBin` takes precedence over `composeBin`

The config fix then prevents the invalid-version fallback from running after a valid custom binary has already been selected. CI now exercises the same assertions against the fix.

Fixes lando/lando#3847.
