### PR TITLE
fix: explain missing service cert paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Improved service certificate errors to recommend rebuilding stale containers [#462](https://github.com/lando/core/issues/462)
 * Fixed interactive sudo password handling to avoid combining `--bell` with `--stdin` [#386](https://github.com/lando/core/issues/386)
 
 ## v3.26.7 - [July 3, 2026](https://github.com/lando/core/releases/tag/v3.26.7)

--- a/scripts/add-cert.sh
+++ b/scripts/add-cert.sh
@@ -23,6 +23,13 @@ if [ $(id -u) != 0 ]; then
   exit 0
 fi
 
+# Cert paths are applied when the service container is created. If they are missing then
+# the container is stale and needs to be recreated before we can install its certificates.
+if [ -z "${LANDO_SERVICE_CERT:-}" ] || [ -z "${LANDO_SERVICE_KEY:-}" ]; then
+  lando_error "Service certificate paths are missing. Run 'lando rebuild' to recreate this container."
+  exit 1
+fi
+
 # Vars and defaults
 : ${LANDO_CA_CERT:="/lando/certs/LandoCA.crt"}
 : ${LANDO_CA_KEY:="/lando/certs/LandoCA.key"}


### PR DESCRIPTION
## What does this pull request do?

Detects missing `LANDO_SERVICE_CERT` or `LANDO_SERVICE_KEY` values before attempting certificate setup and tells the user to run `lando rebuild` to recreate the stale container.

Previously this failed later with the opaque message `chown: cannot access '': No such file or directory`.

Follow-up to #462.

## Testing

- `sh -n scripts/add-cert.sh`
- `git diff --check`
- ShellCheck reports only pre-existing warnings outside the changed lines
- `npm test` could not run because dependencies are not installed (`eslint: not found`)
