### PR TITLE
fix: allow core tests on fork pull requests

### DIFF
--- a/.github/workflows/pr-core-tests.yml
+++ b/.github/workflows/pr-core-tests.yml
@@ -3,6 +3,9 @@ name: Core Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   leia-tests:
     runs-on: ${{ matrix.os }}
@@ -75,11 +78,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
       - name: Install SSH key
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.DEPLOY_KEY }}
           known_hosts: unnecessary
           if_key_exists: replace
+      - name: Generate test SSH key
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keygen -q -t ed25519 -N '' -f ~/.ssh/id_rsa
       - name: Install node ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
@@ -114,9 +123,14 @@ jobs:
           config: |
             setup.skipCommonPlugins=true
       - name: Run Leia Tests
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository ||
+          !contains(fromJSON('["init-github", "plugins"]'), matrix.leia-test)
         uses: lando/run-leia-action@v2
         env:
-          GITHUB_PAT: ${{ secrets.KYBER_AMPLIFICATION_MATRIX }}
+          GITHUB_PAT: >-
+            ${{ github.event.pull_request.head.repo.full_name == github.repository &&
+            secrets.KYBER_AMPLIFICATION_MATRIX || github.token }}
           GITHUB_KEY_NAME: "${{ github.sha }}${{ matrix.os }}"
         with:
           leia-test: "./examples/${{ matrix.leia-test }}/README.md"


### PR DESCRIPTION
## What does this do?

Allows the Core Tests workflow to run safely for pull requests from forks.

- keeps the repository deploy key and privileged GitHub PAT limited to same-repository branches
- generates an ephemeral SSH key for fork PR test jobs
- uses the read-only workflow token for fork PRs
- skips `init-github` and `plugins` Leia tests on forks because they require privileged GitHub credentials
- explicitly limits the workflow token to read-only repository contents

## Why?

GitHub intentionally withholds repository secrets from fork pull requests. The Core Tests matrix currently attempts to install an empty `DEPLOY_KEY`, causing every Leia job to fail before tests run.

This preserves full coverage for trusted branches while allowing the non-privileged suite to validate fork contributions without exposing secrets or using `pull_request_target`.

## Testing

- Parsed the updated workflow as YAML
- `git diff --check`
