### PR TITLE
Fix rogue cert directories causing EISDIR on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Fixed interactive sudo password handling to avoid combining `--bell` with `--stdin` [#386](https://github.com/lando/core/issues/386)
 * Improved the GitHub init source to support `--github-auth=false` for cloning public repositories without a GitHub token or SSH key upload
 * Fixed Node 24 `DEP0187` deprecation warnings from permissive `fs.existsSync()` usage [#474](https://github.com/lando/core/pull/474)
+* Fixed cert generation failing with `EISDIR` when a rogue directory exists at a cert path [#486](https://github.com/lando/core/issues/486)
+* Improved `ssl` services to ensure cert paths exist as files before bind mounting them so Docker cannot create them as directories [#486](https://github.com/lando/core/issues/486)
 
 ## v3.26.7 - [July 3, 2026](https://github.com/lando/core/releases/tag/v3.26.7)
 

--- a/builders/_lando.js
+++ b/builders/_lando.js
@@ -127,11 +127,21 @@ module.exports = {
         // certs
         const certname = `${id}.${project}.crt`;
         const keyname = `${id}.${project}.key`;
+        const certpath = path.join(userConfRoot, 'certs', certname);
+        const keypath = path.join(userConfRoot, 'certs', keyname);
         environment.LANDO_SERVICE_CERT = `/lando/certs/${certname}`;
         environment.LANDO_SERVICE_KEY = `/lando/certs/${keyname}`;
+
+        // ensure the cert paths exist as files before we bind mount them, otherwise docker will
+        // create them as directories and break cert generation downstream
+        // https://github.com/lando/core/issues/486
+        for (const file of [certpath, keypath]) {
+          if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) write(file, '');
+        }
+
         volumes.push(`${addCertsScript}:/scripts/000-add-cert`);
-        volumes.push(`${path.join(userConfRoot, 'certs', certname)}:/certs/cert.crt`);
-        volumes.push(`${path.join(userConfRoot, 'certs', keyname)}:/certs/cert.key`);
+        volumes.push(`${certpath}:/certs/cert.crt`);
+        volumes.push(`${keypath}:/certs/cert.key`);
       }
 
       // Add in some more dirz if it makes sense

--- a/examples/certs/README.md
+++ b/examples/certs/README.md
@@ -18,6 +18,7 @@ lando certinfo || true
 
 # Should start even if rogue directories exist at cert paths
 # https://github.com/lando/core/issues/486
+rm -rf ~/.lando/certs/web.landocerts.crt ~/.lando/certs/web.landocerts.key
 mkdir -p ~/.lando/certs/web.landocerts.crt/rogue ~/.lando/certs/web.landocerts.key/rogue
 lando start
 ```

--- a/examples/certs/README.md
+++ b/examples/certs/README.md
@@ -16,7 +16,9 @@ lando poweroff
 # https://github.com/lando/core/issues/486
 lando certinfo || true
 
-# Should start
+# Should start even if rogue directories exist at cert paths
+# https://github.com/lando/core/issues/486
+mkdir -p ~/.lando/certs/web.landocerts.crt/rogue ~/.lando/certs/web.landocerts.key/rogue
 lando start
 ```
 

--- a/examples/certs/README.md
+++ b/examples/certs/README.md
@@ -9,8 +9,14 @@ See the [Landofiles](https://docs.lando.dev/config/lando.html) in this directory
 ## Start up tests
 
 ```bash
-# Should start
+# Should poweroff
 lando poweroff
+
+# Should be able to run a pre-start command without messing downstream things up
+# https://github.com/lando/core/issues/486
+lando certinfo || true
+
+# Should start
 lando start
 ```
 

--- a/test/write-file.spec.js
+++ b/test/write-file.spec.js
@@ -1,0 +1,72 @@
+/*
+ * Tests for utils/write-file.
+ * @file write-file.spec.js
+ */
+
+'use strict';
+
+// Setup chai.
+const chai = require('chai');
+const expect = chai.expect;
+chai.should();
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Get the module to test
+const write = require('../utils/write-file');
+
+describe('write-file', () => {
+  let tmpdir;
+
+  beforeEach(() => {
+    tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'lando-write-file-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpdir, {force: true, recursive: true});
+  });
+
+  it('should write string data to a file', () => {
+    const file = path.join(tmpdir, 'test.crt');
+    write(file, 'CERTIFICATE DATA');
+    expect(fs.readFileSync(file, 'utf8')).to.equal('CERTIFICATE DATA');
+  });
+
+  it('should create parent directories if they do not exist', () => {
+    const file = path.join(tmpdir, 'certs', 'deeper', 'test.crt');
+    write(file, 'CERTIFICATE DATA');
+    expect(fs.readFileSync(file, 'utf8')).to.equal('CERTIFICATE DATA');
+  });
+
+  it('should overwrite an existing file without replacing its inode', () => {
+    // see https://github.com/lando/core/issues/242, replacing the inode of a bind mounted file
+    // breaks remounts on wsl/docker desktop
+    const file = path.join(tmpdir, 'test.crt');
+    write(file, 'ORIGINAL');
+    const inode = fs.statSync(file).ino;
+    write(file, 'REWRITTEN');
+    expect(fs.readFileSync(file, 'utf8')).to.equal('REWRITTEN');
+    expect(fs.statSync(file).ino).to.equal(inode);
+  });
+
+  it('should recover if a directory exists at the target path', () => {
+    // see https://github.com/lando/core/issues/486, docker compose creates missing bind mount
+    // sources as directories which then blocks cert generation with EISDIR
+    const file = path.join(tmpdir, 'test.crt');
+    fs.mkdirSync(path.join(file, 'rogue'), {recursive: true});
+    write(file, 'CERTIFICATE DATA');
+    expect(fs.statSync(file).isFile()).to.equal(true);
+    expect(fs.readFileSync(file, 'utf8')).to.equal('CERTIFICATE DATA');
+  });
+
+  it('should recover if a directory exists at the target path for json and yaml', () => {
+    for (const ext of ['json', 'yaml']) {
+      const file = path.join(tmpdir, `test.${ext}`);
+      fs.mkdirSync(path.join(file, 'rogue'), {recursive: true});
+      write(file, {lando: true});
+      expect(fs.statSync(file).isFile()).to.equal(true);
+    }
+  });
+});

--- a/utils/write-file.js
+++ b/utils/write-file.js
@@ -6,9 +6,25 @@ const path = require('path');
 
 // @TODO: maybe extension should be in {options}?
 // @TODO: error handling, defaults etc?
+/**
+ * Write data to a file, serializing based on the file extension.
+ *
+ * @param {string} file - Destination file path.
+ * @param {*} data - Data to write.
+ * @param {object} [options] - Write options, also passed to the relevant serializer.
+ * @param {string} [options.extension] - Extension override for serialization format.
+ * @param {boolean} [options.forcePosixLineEndings=false] - Normalize CRLF to LF.
+ * @return {void}
+ */
 module.exports = (file, data, options = {}) => {
   // set extension if not set
   const extension = options.extension || path.extname(file);
+  // if the target path exists as a directory then remove it so we can write a file there instead
+  // this can happen when eg docker compose creates a missing bind mount source as a directory
+  // https://github.com/lando/core/issues/486
+  // @NOTE: we intentionally do not remove existing files here so bind mounted files keep their
+  // inode across rewrites, see https://github.com/lando/core/issues/242
+  if (fs.existsSync(file) && fs.statSync(file).isDirectory()) require('./remove')(file);
   // linux line endings
   const forcePosixLineEndings = options.forcePosixLineEndings ?? false;
 


### PR DESCRIPTION
Fixes #486

Docker creates missing bind-mount sources as *directories*. The v3 `lando` service bind-mounts `~/.lando/certs/<id>.<project>.crt|key` whenever `ssl: true`, but those files are only generated at `pre-start`, so if Docker ever touches those mounts while the files are missing it leaves rogue directories behind — and cert generation then dies with `EISDIR` on every subsequent `lando start`/`rebuild`.

The first commits add a deterministic repro to the certs leia spec (rogue dirs at the cert paths before `lando start`), which failed CI with the exact error from the issue ([failing run](https://github.com/lando/core/actions/runs/31339869440)):

```
ERROR ==> EISDIR: illegal operation on a directory, open '/home/runner/.lando/certs/web.landocerts.crt'
```

Then the fix, in two layers:

* **Recovery** — `utils/write-file.js` now removes a directory sitting at the target path before writing. Existing *files* are never removed so bind-mounted files keep their inode across rewrites, preserving the #242 WSL fix. Unit tests cover both behaviors.
* **Prevention** — `builders/_lando.js` ensures the cert paths exist as (possibly empty) files before they are ever bind-mounted, so Docker can no longer fabricate directories there in the first place.