### PR TITLE
Harden v4 bind mount source creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fixed Node 24 `DEP0187` deprecation warnings from permissive `fs.existsSync()` usage [#474](https://github.com/lando/core/pull/474)
 * Fixed cert generation failing with `EISDIR` when a rogue directory exists at a cert path [#486](https://github.com/lando/core/issues/486)
 * Improved `ssl` services to ensure cert paths exist as files before bind mounting them so Docker cannot create them as directories [#486](https://github.com/lando/core/issues/486)
+* Improved v4 bind mounts to respect `create_host_path: false` so Lando no longer creates missing bind sources that users manage themselves [#486](https://github.com/lando/core/issues/486)
+* Fixed the v4 `/run/host-services` bind mount exception matching unrelated paths that share the prefix
 
 ## v3.26.7 - [July 3, 2026](https://github.com/lando/core/releases/tag/v3.26.7)
 

--- a/components/l337-v4.js
+++ b/components/l337-v4.js
@@ -726,8 +726,14 @@ class L337ServiceV4 extends EventEmitter {
     return file;
   }
 
+  /**
+   * Normalize compose volume input into long syntax objects and ensure bind mount sources exist.
+   *
+   * @param {Array<string|object>} [volumes] - Compose style volume definitions.
+   * @return {Array<string|object>} Normalized volume definitions.
+   */
   normalizeVolumes(volumes = []) {
-    if (!Array.isArray) return [];
+    if (!Array.isArray(volumes)) return [];
 
     // normalize and return
     return volumes.map(volume => {
@@ -760,13 +766,22 @@ class L337ServiceV4 extends EventEmitter {
         volume.source = path.join(this.appRoot, volume.source);
       }
 
-      // if the bind mount source does not exist then attempt to create it?
+      // if the bind mount source does not exist then attempt to create it as a directory so the
+      // invoking user owns it instead of whatever docker decides to do with it
       // we make an "exception" for any /run/host-services things that are in the docker vm
-      // @NOTE: is this actually a good idea?
+      // and we also allow the user to opt out with bind.create_host_path: false eg for sources
+      // that are meant to be files they manage themselves
+      // https://github.com/lando/core/issues/486
       if (volume.type === 'bind'
         && !fs.existsSync(volume.source)
-        && !volume.source.startsWith('/run/host-services')) {
-        fs.mkdirSync(volume.source, {recursive: true});
+        && volume.source !== '/run/host-services'
+        && !volume.source.startsWith('/run/host-services/')) {
+        if (volume.bind?.create_host_path === false) {
+          this.debug('not creating missing bind mount source %o because create_host_path is false', volume.source);
+        } else {
+          fs.mkdirSync(volume.source, {recursive: true});
+          this.debug('created missing bind mount source %o as a directory for %o', volume.source, volume.target);
+        }
       }
 
       // return

--- a/test/normalize-volumes.spec.js
+++ b/test/normalize-volumes.spec.js
@@ -1,0 +1,106 @@
+/*
+ * Tests for components/l337-v4 normalizeVolumes.
+ * @file normalize-volumes.spec.js
+ */
+
+'use strict';
+
+// Setup chai.
+const chai = require('chai');
+const expect = chai.expect;
+chai.should();
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Get the module to test
+const L337ServiceV4 = require('../components/l337-v4');
+
+describe('l337-v4 normalizeVolumes', () => {
+  let appRoot;
+  let context;
+
+  // run normalizeVolumes with a minimal stubbed this
+  const normalize = volumes => L337ServiceV4.prototype.normalizeVolumes.call(context, volumes);
+
+  beforeEach(() => {
+    appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lando-normalize-volumes-test-'));
+    context = {
+      _data: {volumes: ['some-named-volume']},
+      appRoot,
+      debug: () => {},
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(appRoot, {force: true, recursive: true});
+  });
+
+  it('should return an empty array for non-array input', () => {
+    expect(normalize('not-an-array')).to.deep.equal([]);
+    expect(normalize({source: 'nope'})).to.deep.equal([]);
+  });
+
+  it('should pass through one part strings', () => {
+    expect(normalize(['/some/anon/volume'])).to.deep.equal(['/some/anon/volume']);
+  });
+
+  it('should normalize two and three part strings into objects', () => {
+    const source = path.join(appRoot, 'exists');
+    fs.mkdirSync(source);
+    const [two, three] = normalize([`${source}:/here`, `${source}:/there:ro`]);
+    expect(two).to.deep.equal({source, target: '/here', type: 'bind'});
+    expect(three).to.deep.equal({source, target: '/there', type: 'bind', read_only: true});
+  });
+
+  it('should resolve relative bind sources from the app root', () => {
+    const [volume] = normalize(['./relative:/here']);
+    expect(volume.source).to.equal(path.join(appRoot, 'relative'));
+    expect(fs.statSync(volume.source).isDirectory()).to.equal(true);
+  });
+
+  it('should type named volumes as volumes and not create anything on the host', () => {
+    const [volume] = normalize([{source: 'some-named-volume', target: '/here'}]);
+    expect(volume.type).to.equal('volume');
+    expect(fs.existsSync(path.join(appRoot, 'some-named-volume'))).to.equal(false);
+  });
+
+  it('should create missing bind sources as directories', () => {
+    const source = path.join(appRoot, 'missing');
+    normalize([`${source}:/here`]);
+    expect(fs.statSync(source).isDirectory()).to.equal(true);
+  });
+
+  it('should not touch bind sources that already exist as files', () => {
+    const source = path.join(appRoot, 'config.conf');
+    fs.writeFileSync(source, 'config');
+    const inode = fs.statSync(source).ino;
+    normalize([`${source}:/here`]);
+    expect(fs.statSync(source).isFile()).to.equal(true);
+    expect(fs.statSync(source).ino).to.equal(inode);
+    expect(fs.readFileSync(source, 'utf8')).to.equal('config');
+  });
+
+  it('should not create missing bind sources when create_host_path is false', () => {
+    const source = path.join(appRoot, 'user-managed.conf');
+    const [volume] = normalize([{source, target: '/here', bind: {create_host_path: false}}]);
+    expect(fs.existsSync(source)).to.equal(false);
+    expect(volume.bind).to.deep.equal({create_host_path: false});
+  });
+
+  it('should create missing bind sources when create_host_path is true', () => {
+    const source = path.join(appRoot, 'compose-managed');
+    normalize([{source, target: '/here', bind: {create_host_path: true}}]);
+    expect(fs.statSync(source).isDirectory()).to.equal(true);
+  });
+
+  it('should not create anything for host-services sources in the docker vm', () => {
+    const sources = ['/run/host-services', '/run/host-services/ssh-auth.sock'];
+    const volumes = normalize(sources.map(source => ({source, target: source})));
+    for (const [index, source] of sources.entries()) {
+      expect(volumes[index].source).to.equal(source);
+      expect(fs.existsSync(source)).to.equal(false);
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #488 / #486 for the v4 engine.

`normalizeVolumes()` in `components/l337-v4.js` creates missing bind-mount sources as directories indiscriminately — including sources that are clearly meant to be *files* (e.g. `./missing.conf:/etc/nginx/conf.d/default.conf`), which leaves rogue directories in the user's project and produces confusing container start errors. This is the same bug class as #486, except here Lando fabricates the directory itself before Docker can.

Since file-vs-dir intent cannot be safely inferred from the path alone (`conf.d`, `example.com`, etc. defeat any extension heuristic), this keeps the backwards-compatible directory default and adds explicit control instead:

* **`bind.create_host_path: false`** (standard compose long syntax) is now respected as an opt-out — Lando creates nothing, so users who mount files they manage themselves get Docker's clear "bind source path does not exist" instead of a rogue directory.
* **`/run/host-services` exception is now boundary-aware** — previously it prefix-matched any path starting with that string (e.g. `/run/host-services-foo`).
* **Fixed a latent `if (!Array.isArray)` bug** (missing call — the guard was always falsy) so non-array input is actually rejected.
* Directory creation is now debug-logged with source and target.

Unit tests cover the normalization matrix: string short-syntax parsing, named volumes, relative source resolution, missing-source creation, existing-file preservation (inode-stable), the `create_host_path` opt-in/opt-out, and the host-services exception.