### PR TITLE
fix: surface real git errors instead of fake tar detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Fixed `lando init` mis-detecting failed git clones (including `ssh://` Pantheon URLs) as tar archives and then failing with a misleading curl protocol error
+* Fixed `lando init` treating failed git clones as tar archives
 
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)
 
+* Fixed `lando init` mis-detecting failed git clones (including `ssh://` Pantheon URLs) as tar archives and then failing with a misleading curl protocol error
 * Updated Docker Desktop `tested` range to `<=4.85.99`, default `lando setup` install to 4.85.0, and Desktop installer build-id maps so current Desktop users are no longer treated as pioneers [#472](https://github.com/lando/core/issues/472)
 * Updated default Docker Compose orchestrator to `2.40.3` and Compose `tested` range to `<=2.40.99`
 * Updated default Docker Engine to `29.6.2` (matches Docker Desktop 4.85.x) and Engine `tested` range to `<=29.6.99`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed `lando init` mis-detecting failed git clones (including `ssh://` Pantheon URLs) as tar archives and then failing with a misleading curl protocol error
+
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)
 
-* Fixed `lando init` mis-detecting failed git clones (including `ssh://` Pantheon URLs) as tar archives and then failing with a misleading curl protocol error
 * Updated Docker Desktop `tested` range to `<=4.85.99`, default `lando setup` install to 4.85.0, and Desktop installer build-id maps so current Desktop users are no longer treated as pioneers [#472](https://github.com/lando/core/issues/472)
 * Updated default Docker Compose orchestrator to `2.40.3` and Compose `tested` range to `<=2.40.99`
 * Updated default Docker Engine to `29.6.2` (matches Docker Desktop 4.85.x) and Engine `tested` range to `<=29.6.99`

--- a/scripts/get-remote-url.sh
+++ b/scripts/get-remote-url.sh
@@ -11,9 +11,37 @@ else
   OPTIONS="$2"
 fi
 
-# Determine whether this is an archive or a giturl and set other helpers
-TYPE=$(git ls-remote "$URL" --quiet 2>/dev/null && echo "git repo" || echo "tar archive")
 SRC_DIR=/tmp/source
+
+is_http_url() {
+  case "$1" in
+    http://*|https://*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_git_url() {
+  case "$1" in
+    ssh://*|git://*|git@*|*.git) return 0 ;;
+  esac
+  case "$1" in
+    *://*) return 1 ;;
+    *@*:*) return 0 ;;
+  esac
+  return 1
+}
+
+if is_git_url "$URL"; then
+  TYPE="git repo"
+elif is_http_url "$URL" && git ls-remote "$URL" --quiet >/dev/null 2>&1; then
+  TYPE="git repo"
+elif is_http_url "$URL"; then
+  TYPE="tar archive"
+else
+  echo "Could not fetch $URL as a git repository." >&2
+  echo "Refusing to download a non-http(s) URL as an archive." >&2
+  exit 1
+fi
 
 # Do some basic reporting
 echo "Detected that $URL is a $TYPE"

--- a/scripts/get-remote-url.sh
+++ b/scripts/get-remote-url.sh
@@ -64,6 +64,11 @@ fi
 
 # Or archive
 if [ "$TYPE" = "tar archive" ]; then
+  if ! is_http_url "$URL"; then
+    echo "Cannot download $URL as an archive." >&2
+    echo "Only http(s) archive URLs are supported." >&2
+    exit 1
+  fi
   echo "Downloading $URL..."
   cd "$SRC_DIR" && curl -fsSL -O "$URL"
 


### PR DESCRIPTION
## What Problem This Solves

`lando init` from a git source (Pantheon especially) can print:

```
Detected that ssh://codeserver.dev.UUID@codeserver.dev.UUID.drush.in:2222/~/repository.git is a tar archive
Downloading ssh://...
curl: (1) Protocol "ssh" not supported or disabled in libcurl
```

That is a lie. `scripts/get-remote-url.sh` ran `git ls-remote`, swallowed stderr, and treated **any** failure (publickey, DNS, timeout) as "this must be a tarball". Then it handed an `ssh://` URL to curl.

Same symptom as the old reports in lando/lando#1745 and lando/pantheon#142.

## Why This Change Was Made

Git-looking URLs (`ssh://`, `git://`, `git@`, `*.git`, scp-like `user@host:path`) are now always cloned. Failures print the real git/SSH error and exit. Non-http(s) URLs are never downloaded as archives.

http(s) remotes still probe with `git ls-remote` and fall back to the existing archive extract path when that probe fails.

## User Impact

A failed `lando init --source pantheon` (or remote/github git clone) now shows the actual clone problem instead of a fake curl/libcurl protocol error. People will stop "fixing" host curl.

http(s) tarball init is unchanged.

## Evidence

- `bash -n scripts/get-remote-url.sh`
- `ssh://.../repository.git` can no longer reach the curl branch
- http(s) archive download/extract path is still there
- Reproduced locally before this change with `lando init --source pantheon --pantheon-site aaron-11`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to init remote URL detection in one shell script; behavior improves error reporting for git remotes with minimal impact on the http(s) archive path.
> 
> **Overview**
> **`lando init`** remote fetching no longer treats a failed `git ls-remote` as “this must be a tarball.” In **`scripts/get-remote-url.sh`**, URL handling is replaced with explicit **`is_git_url`** / **`is_http_url`** checks: SSH, `git://`, `git@`, `*.git`, and scp-style remotes always go through **git clone**, so auth/DNS/SSH failures surface as real git errors instead of a misleading curl “Protocol ssh not supported” path.
> 
> **http(s)** URLs still probe with `git ls-remote` and can fall back to the existing archive download/extract flow when the probe fails. Non-http(s) URLs that are not classified as git now **exit with a clear error** rather than being passed to curl; the archive branch also refuses non-http(s) downloads.
> 
> CHANGELOG records the fix under unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d21d64e98105b588559ae6e724521825d04e871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->