### PR TITLE
fix: copy SSH keys off bind mounts on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Fixed SSH keys bind-mounted as root on Docker Desktop Mac being ignored by `load-keys.sh`
+* Fixed `load-keys.sh` ignoring SSH keys that Docker bind-mounts as root
 * Fixed `lando init` treating failed git clones as tar archives
 
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Fixed SSH keys bind-mounted as root on Docker Desktop Mac being ignored by `load-keys.sh`
 * Fixed `lando init` treating failed git clones as tar archives
 
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
-* Fixed `load-keys.sh` ignoring SSH keys that Docker bind-mounts as root
+* Fixed `load-keys.sh` using bind-mounted SSH keys by copying them to `/lando_keys` on all platforms
 * Fixed `lando init` treating failed git clones as tar archives
 
 ## v3.26.8 - [August 10, 2026](https://github.com/lando/core/releases/tag/v3.26.8)

--- a/examples/keys/README.md
+++ b/examples/keys/README.md
@@ -21,10 +21,10 @@ Run the following commands to verify things work as expected
 
 ```bash
 # Should have our keys
-lando exec cli -u root -- cat /etc/ssh/ssh_config | grep "/lando/keys/badbadkey"
-lando exec cli2 -u root -- cat /etc/ssh/ssh_config | grep "/lando/keys/ppkey"
-lando exec cli2 -u root -- cat /etc/ssh/ssh_config | grep "/lando/keys/key with space"
-lando exec thesekeys -u root -- cat /etc/ssh/ssh_config | grep "/user/.ssh/mykey3"
+lando exec cli -u root -- cat /etc/ssh/ssh_config | grep "/lando_keys/badbadkey"
+lando exec cli2 -u root -- cat /etc/ssh/ssh_config | grep "/lando_keys/ppkey"
+lando exec cli2 -u root -- cat /etc/ssh/ssh_config | grep "/lando_keys/key with space"
+lando exec thesekeys -u root -- cat /etc/ssh/ssh_config | grep "/lando_keys/mykey3"
 
 # Should have the LANDO_LOAD_KEYS envvar set correctly by default
 lando exec cli -- env | grep LANDO_LOAD_KEYS | grep true
@@ -40,9 +40,9 @@ lando exec cli -- cat /etc/ssh/ssh_config | grep "/user/.ssh" || echo "$?" | gre
 cp -f .lando.local.yml.thesekeys .lando.local.yml
 lando rebuild -y
 lando exec thesekeys -- env | grep LANDO_LOAD_KEYS | grep "mykey mykey2"
-lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/user/.ssh/mykey"
-lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/user/.ssh/mykey2"
-lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/user/.ssh/mykey3" || echo "$?" | grep 1
+lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/lando_keys/mykey"
+lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/lando_keys/mykey2"
+lando exec thesekeys -- cat /etc/ssh/ssh_config | grep "/lando_keys/mykey3" || echo "$?" | grep 1
 ```
 
 ## Destroy tests

--- a/scripts/load-keys.sh
+++ b/scripts/load-keys.sh
@@ -50,8 +50,8 @@ done
 
 # We need to do some different magic on Windows because file sharing on windows
 # does not let you chmod files that are mounted
-if [ "$LANDO_HOST_OS" = "win32" ] || [ "$LANDO_HOST_OS" = "darwin" ]; then
-  lando_warn "Creating a special not-mounted key directory"
+if [ "$LANDO_HOST_OS" = "win32" ]; then
+  lando_warn "Creating a special not-mounted key directory for Windows"
   mkdir -p /lando_keys
   for SSH_DIR in "${SSH_DIRS[@]}"; do
     readarray -t SSH_KEYS < <(find "$SSH_DIR" -maxdepth 1 -not -name 'known_hosts' -type f)
@@ -68,7 +68,7 @@ fi
 # Scan the following directories for keys and filter out non-private keys
 for SSH_DIR in "${SSH_DIRS[@]}"; do
   lando_info "Scanning $SSH_DIR for keys..."
-  readarray -t RAW_LIST < <(find "$SSH_DIR" -maxdepth 1 -not -name '*.pub' -not -name 'known_hosts' -user $LANDO_WEBROOT_USER -type f)
+  readarray -t RAW_LIST < <(find "$SSH_DIR" -maxdepth 1 -not -name '*.pub' -not -name 'known_hosts' -type f)
   for RAW_KEY in "${RAW_LIST[@]}"; do
     SSH_CANDIDATES+=("$RAW_KEY")
   done
@@ -87,8 +87,16 @@ lando_info "Found keys ${SSH_CANDIDATES[*]}"
 # Go through and validate our candidates
 for SSH_CANDIDATE in "${SSH_CANDIDATES[@]}"; do
   lando_debug "Ensuring permissions and ownership of $SSH_CANDIDATE..."
-  chown -R $LANDO_WEBROOT_USER:$GROUP "$SSH_CANDIDATE"
-  chmod 600 "$SSH_CANDIDATE"
+  chown -R $LANDO_WEBROOT_USER:$GROUP "$SSH_CANDIDATE" || true
+  chmod 600 "$SSH_CANDIDATE" || true
+  if ! su "$LANDO_WEBROOT_USER" -s /bin/sh -c "test -r \"$SSH_CANDIDATE\""; then
+    mkdir -p /lando_keys
+    KEY_COPY="/lando_keys/$(basename "$SSH_CANDIDATE")"
+    cp -fp "$SSH_CANDIDATE" "$KEY_COPY"
+    chown -R $LANDO_WEBROOT_USER:$GROUP "$KEY_COPY"
+    chmod 600 "$KEY_COPY"
+    SSH_CANDIDATE="$KEY_COPY"
+  fi
   lando_debug "Checking whether $SSH_CANDIDATE is a private key..."
   if grep -l "PRIVATE KEY" "$SSH_CANDIDATE" &> /dev/null; then
     if command -v ssh-keygen >/dev/null 2>&1; then

--- a/scripts/load-keys.sh
+++ b/scripts/load-keys.sh
@@ -48,6 +48,7 @@ for SSH_DIR in "${SSH_DIRS[@]}"; do
   mkdir -p "$SSH_DIR"
 done
 
+rm -rf /lando_keys
 mkdir -p /lando_keys
 for SSH_DIR in "${SSH_DIRS[@]}"; do
   readarray -t SSH_KEYS < <(find "$SSH_DIR" -maxdepth 1 -not -name 'known_hosts' -type f)

--- a/scripts/load-keys.sh
+++ b/scripts/load-keys.sh
@@ -50,8 +50,8 @@ done
 
 # We need to do some different magic on Windows because file sharing on windows
 # does not let you chmod files that are mounted
-if [ "$LANDO_HOST_OS" = "win32" ]; then
-  lando_warn "Creating a special not-mounted key directory for Windows"
+if [ "$LANDO_HOST_OS" = "win32" ] || [ "$LANDO_HOST_OS" = "darwin" ]; then
+  lando_warn "Creating a special not-mounted key directory"
   mkdir -p /lando_keys
   for SSH_DIR in "${SSH_DIRS[@]}"; do
     readarray -t SSH_KEYS < <(find "$SSH_DIR" -maxdepth 1 -not -name 'known_hosts' -type f)

--- a/scripts/load-keys.sh
+++ b/scripts/load-keys.sh
@@ -48,22 +48,17 @@ for SSH_DIR in "${SSH_DIRS[@]}"; do
   mkdir -p "$SSH_DIR"
 done
 
-# We need to do some different magic on Windows because file sharing on windows
-# does not let you chmod files that are mounted
-if [ "$LANDO_HOST_OS" = "win32" ]; then
-  lando_warn "Creating a special not-mounted key directory for Windows"
-  mkdir -p /lando_keys
-  for SSH_DIR in "${SSH_DIRS[@]}"; do
-    readarray -t SSH_KEYS < <(find "$SSH_DIR" -maxdepth 1 -not -name 'known_hosts' -type f)
-    for SSH_KEY in "${SSH_KEYS[@]}"; do
-      lando_debug "Copying $SSH_KEY from $SSH_DIR to /lando_keys"
-      cp -rfp "$SSH_KEY" /lando_keys
-    done
+mkdir -p /lando_keys
+for SSH_DIR in "${SSH_DIRS[@]}"; do
+  readarray -t SSH_KEYS < <(find "$SSH_DIR" -maxdepth 1 -not -name 'known_hosts' -type f)
+  for SSH_KEY in "${SSH_KEYS[@]}"; do
+    lando_debug "Copying $SSH_KEY from $SSH_DIR to /lando_keys"
+    cp -rfp "$SSH_KEY" /lando_keys
   done
-  chown -R $LANDO_WEBROOT_USER:$GROUP /lando_keys
-  SSH_DIRS=( "/lando_keys" )
-  SSH_KEYS=()
-fi
+done
+chown -R $LANDO_WEBROOT_USER:$GROUP /lando_keys
+SSH_DIRS=( "/lando_keys" )
+SSH_KEYS=()
 
 # Scan the following directories for keys and filter out non-private keys
 for SSH_DIR in "${SSH_DIRS[@]}"; do
@@ -78,7 +73,12 @@ done
 if [ "$LANDO_LOAD_KEYS" != "true" ] && [ "$LANDO_LOAD_KEYS" != "false" ]; then
   RAW_LIST=($LANDO_LOAD_KEYS)
   for RAW_KEY in "${RAW_LIST[@]}"; do
-    SSH_CANDIDATES+=("/user/.ssh/$RAW_KEY")
+    if [ -f "/user/.ssh/$RAW_KEY" ]; then
+      cp -fp "/user/.ssh/$RAW_KEY" "/lando_keys/$RAW_KEY"
+      chown $LANDO_WEBROOT_USER:$GROUP "/lando_keys/$RAW_KEY"
+      chmod 600 "/lando_keys/$RAW_KEY"
+      SSH_CANDIDATES+=("/lando_keys/$RAW_KEY")
+    fi
   done
 fi
 
@@ -87,16 +87,8 @@ lando_info "Found keys ${SSH_CANDIDATES[*]}"
 # Go through and validate our candidates
 for SSH_CANDIDATE in "${SSH_CANDIDATES[@]}"; do
   lando_debug "Ensuring permissions and ownership of $SSH_CANDIDATE..."
-  chown -R $LANDO_WEBROOT_USER:$GROUP "$SSH_CANDIDATE" || true
-  chmod 600 "$SSH_CANDIDATE" || true
-  if ! su "$LANDO_WEBROOT_USER" -s /bin/sh -c "test -r \"$SSH_CANDIDATE\""; then
-    mkdir -p /lando_keys
-    KEY_COPY="/lando_keys/$(basename "$SSH_CANDIDATE")"
-    cp -fp "$SSH_CANDIDATE" "$KEY_COPY"
-    chown -R $LANDO_WEBROOT_USER:$GROUP "$KEY_COPY"
-    chmod 600 "$KEY_COPY"
-    SSH_CANDIDATE="$KEY_COPY"
-  fi
+  chown -R $LANDO_WEBROOT_USER:$GROUP "$SSH_CANDIDATE"
+  chmod 600 "$SSH_CANDIDATE"
   lando_debug "Checking whether $SSH_CANDIDATE is a private key..."
   if grep -l "PRIVATE KEY" "$SSH_CANDIDATE" &> /dev/null; then
     if command -v ssh-keygen >/dev/null 2>&1; then


### PR DESCRIPTION
## What Problem This Solves

Docker bind-mounted SSH keys often show up as root-owned (especially Docker Desktop Mac with virtiofs). `load-keys.sh` then either cannot chmod them or skips them, so git/SSH inside the container has no IdentityFile.

## Why This Change Was Made

Windows already copied keys to `/lando_keys` because bind mounts cannot be chmod'd. That is the correct model on every OS: copy off the mount, chown the copy, never SSH with the live bind mount.

## User Impact

Mac `lando init --source pantheon` and other SSH-using commands can use the Lando key without switching Docker file sharing. Linux/Windows behavior matches: keys are copied, then loaded.

## Evidence

- User repro: container hash matched host, file owned by root
- Windows already used `/lando_keys` for this reason
- Keys example checks now grep `/lando_keys/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core container SSH key loading for every OS; mis-copy or permission bugs would break git/SSH in apps, but scope is limited to `load-keys.sh`.
> 
> **Overview**
> **SSH keys are always staged in `/lando_keys` before use**, extending the Windows-only workaround to every host OS so bind-mounted keys (often root-owned on Docker Desktop Mac) can be `chown`/`chmod` and registered as `IdentityFile` in `ssh_config`.
> 
> `load-keys.sh` now wipes and repopulates `/lando_keys` from `/lando/keys`, `/var/www/.ssh`, and optionally `/user/.ssh`, then scans only that directory. Key discovery no longer filters by `-user $LANDO_WEBROOT_USER`, and explicit `LANDO_LOAD_KEYS` names are copied from `/user/.ssh` into `/lando_keys` instead of referencing the mount directly. The keys example README and CHANGELOG document the new paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717770137918c3a59706f4ddaa19939b9be54d77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->